### PR TITLE
Fix internal link

### DIFF
--- a/docs/content_management/create_edit_content_items.md
+++ b/docs/content_management/create_edit_content_items.md
@@ -134,7 +134,7 @@ This action opens a new browser tab with an editing screen of the selected Conte
 When you finish editing the item, click **Publish**.
 To see implemented changes refresh the browser page.
 
-This option is also available when you want to set up a [relation](../configure_ct_field_settings/#content-relation-settings) with another Content item.
+This option is also available when you want to set up a [relation](configure_ct_field_settings.md#content-relation-settings) with another Content item.
 
 ![Edit embedded Content item - set up a relation](img/edit_embedded_items_relation.png "Edit embedded Content item - set up a relation")
 

--- a/docs/content_management/create_edit_content_items.md
+++ b/docs/content_management/create_edit_content_items.md
@@ -209,4 +209,3 @@ For this feature to work as described, the Content Type must have a **Metadata**
 ![Selecting Taxonomy entries](img/taxonomy_select_taxonomy_entries.png "Selecting Taxonomy entries")
 
 For more information, see [Assign tag to content from taxonomy tree](taxonomy/work_with_tags.md#assign-tag-to-content-from-taxonomy-tree).
-


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | N/A
| Versions      | 4.6, 4.5
| Edition       | All

Fix internal link:

```
INFO    -  Doc file 'content_management/create_edit_content_items.md' contains an unrecognized relative link '../configure_ct_field_settings/#content-relation-settings', it was left as is. Did you mean
           'configure_ct_field_settings.md#content-relation-settings'?
```

Left one new line at the end of the file instead of two.

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Added link to this PR in relevant JIRA ticket or code PR
