### PR TITLE
Fix index links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -144,8 +144,10 @@
             <div class="info-tile info-tile--link-card">
                 <div class="info-tile__content">
                     <h3>
-                        <svg><use xlink:href="images/icons.svg#content-draft" /></svg>
-                        Content
+                        <a href="content_management/content_items/">
+                            <svg><use xlink:href="images/icons.svg#content-draft" /></svg>
+                            Content
+                        </a>
                     </h3>
                     <ul>
                         <li><a href="persona_paths/manage_content_model/">Manage content model</a></li>
@@ -196,8 +198,10 @@
             <div class="info-tile info-tile--link-card">
                 <div class="info-tile__content">
                     <h3>
-                        <svg><use xlink:href="images/icons.svg#profile" /></svg>
-                        Customer
+                        <a href="customer_management/customer_portal/">
+                            <svg><use xlink:href="images/icons.svg#profile" /></svg>
+                            Customer
+                        </a>
                     </h3>
                     <ul>
                         <li><a href="customer_management/customer_portal/">Manage Customer Portal account</a></li>

--- a/docs/index.md
+++ b/docs/index.md
@@ -144,10 +144,8 @@
             <div class="info-tile info-tile--link-card">
                 <div class="info-tile__content">
                     <h3>
-                        <a href="content_management/content_management/">
-                            <svg><use xlink:href="images/icons.svg#content-draft" /></svg>
-                            Content
-                        </a>
+                        <svg><use xlink:href="images/icons.svg#content-draft" /></svg>
+                        Content
                     </h3>
                     <ul>
                         <li><a href="persona_paths/manage_content_model/">Manage content model</a></li>
@@ -198,10 +196,8 @@
             <div class="info-tile info-tile--link-card">
                 <div class="info-tile__content">
                     <h3>
-                        <a href="customer_management/customer_management/">
-                            <svg><use xlink:href="images/icons.svg#profile" /></svg>
-                            Customer
-                        </a>
+                        <svg><use xlink:href="images/icons.svg#profile" /></svg>
+                        Customer
                     </h3>
                     <ul>
                         <li><a href="customer_management/customer_portal/">Manage Customer Portal account</a></li>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | N/A
| Versions      | master, 4.6, 4.5
| Edition       | All

On https://doc.ibexa.co/projects/userguide/en/master/ in "Manage your DXP" the links on "Content" and "Customer" block titles are broken.

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Added link to this PR in relevant JIRA ticket or code PR
