### PR TITLE
IBX-7909: `Content item` changed to `content item` in User documentation

### DIFF
--- a/docs/content_management/block_reference.md
+++ b/docs/content_management/block_reference.md
@@ -9,28 +9,28 @@ The following blocks are provided with a clean installation of [[= product_name 
 
 |Block|Description|
 |-----|-----------|
-|[Banner](#banner-block)|Displays an image Content item with a URL attached to it.|
+|[Banner](#banner-block)|Displays an image content item with a URL attached to it.|
 |[Bestsellers](#bestsellers-block)|Displays a list of products that were recently a bestseller.|
 |[Catalog](#catalog-block)|Displays products from a specific catalog to a selected customer group.|
 |[Code](#code-block)|Enables you to place text, links, images, etc. on your Page using custom HTML.|
-|[Collection](#collection-block)|Displays a set of Content items you select manually from the Content structure. |
-|[Content List](#content-list-block)|Displays Content items of a chosen content type (or Types) that are contained in a selected folder. |
-|[Content Scheduler](schedule_publishing.md#content-scheduler-block)|Displays Content items at a pre-defined time. |
+|[Collection](#collection-block)|Displays a set of content items you select manually from the Content structure. |
+|[Content List](#content-list-block)|Displays content items of a chosen content type (or Types) that are contained in a selected folder. |
+|[Content Scheduler](schedule_publishing.md#content-scheduler-block)|Displays content items at a pre-defined time. |
 |[Dynamic targeting](#dynamic-targeting-block)|Embeds recommended items based on the [Segment](content_organization/classify_content.md#segments) the user belongs to. |
-|[Embed](#embed-block)|Embeds a Content item of any content type on the Page. |
-|[Form](#form-block)|Embeds a Form Content item that you select from the Content Structure. |
+|[Embed](#embed-block)|Embeds a content item of any content type on the Page. |
+|[Form](#form-block)|Embeds a Form content item that you select from the Content Structure. |
 |[Gallery](#gallery-block)|Displays all images contained in a selected folder. |
 |[Ibexa Connect](#ibexa-connect-block)|Retrieves and displays data from an Ibexa Connect webhook. |
 |[Last purchased](#last-purchased-block)|Displays a list of products that were recently purchased from PIM. |
 |[Last viewed](#last-viewed-block)|Displays a list of products from PIM that were recently viewed. |
 |[Orders](#orders-block)|Displays a list of orders associated with a particular company or individual customer. |
-|[Personalized](#personalized-block)|Displays a list of Content items/products that are recommended to end users when specific scenarios are triggered. |
+|[Personalized](#personalized-block)|Displays a list of content items/products that are recommended to end users when specific scenarios are triggered. |
 |[Product collection](#product-collection-block)|Displays a list of specifically selected products.|
 |[Recently added](#recently-added-block)|Displays a list of products that were recently added to PIM. |
 |[RSS](#rss-block)|Loads and displays news from RSS feeds (channels). |
 |[Sales representative](#sales-representative)|Loads and displays company's sales representative.|
 |[SeenThis!](#seenthis-block)|Displays video with exceeded standard video restrictions of 3.5MB.|
-|[Targeting](#targeting-block)|Embeds an Content item based on the [Segment](content_organization/classify_content.md#segments) the user belongs to. |
+|[Targeting](#targeting-block)|Embeds an content item based on the [Segment](content_organization/classify_content.md#segments) the user belongs to. |
 |[Text](#text-block)|Enables you to add to the Page a Rich Text block. |
 |[Video](#video-block)|Embeds a video into the Page with standard playback controls. |
 
@@ -112,22 +112,22 @@ On the **Properties** tab, set values in the following fields:
 
 ## Collection block
 
-Displays a collection of Content items manually selected from the Content structure, allowing you to feature specific content for promotional campaigns or highlight essential information on your website.
+Displays a collection of content items manually selected from the Content structure, allowing you to feature specific content for promotional campaigns or highlight essential information on your website.
 On the **Properties** tab, set values in the following fields:
 
 - **Name** — Enter a name for the page block.
-- **Location list** — Click **Select content**, browse the available content, and add to the collection Content items of any content type you want.
+- **Location list** — Click **Select content**, browse the available content, and add to the collection content items of any content type you want.
 
-All selected Content items appear in the **Selected items** box at the bottom of the window.
+All selected content items appear in the **Selected items** box at the bottom of the window.
 When done selecting, click **Confirm**.
 
 ## Content List block
 
-Displays Content items of specified content type from a selected folder, simplifying access to categorized information or targeted content presentation on your site.
+Displays content items of specified content type from a selected folder, simplifying access to categorized information or targeted content presentation on your site.
 On the **Properties** tab, set values in the following fields:
 
 - **Name** — Enter a name for the page block.
-- **Parent** — Click **Select content**, browse the content, and select a folder containing Content items to display in the list.
+- **Parent** — Click **Select content**, browse the content, and select a folder containing content items to display in the list.
 - **Limit** — Set the number of products to be displayed.
 - **Content types to be displayed** — Select content type(s) to be displayed.
 
@@ -149,22 +149,22 @@ The rules are checked in order, so when a user belongs to more than one Segment,
 
 ## Embed block
 
-Place any Content item directly on the page. This function works across all content types seamlessly.
+Place any content item directly on the page. This function works across all content types seamlessly.
 On the **Properties** tab, set values in the following fields:
 
 - **Name** — Enter a name for the page block.
-- **Content** — Click **Select content**, browse the content, and select a Content item.
+- **Content** — Click **Select content**, browse the content, and select a content item.
 
 ## Form block
 
 Place a selected form from the content structure onto the page.
 Integrate specific forms into your content to enhance client interaction.
-Completing the settings of the Form block requires at least one Form Content item created.
+Completing the settings of the Form block requires at least one Form content item created.
 
 On the **Properties** tab, set values in the following fields:
 
 - **Name** — Enter a name for the page block.
-- **Form** — Click **Select content**, browse the content, and select a Form Content item to append it to the block.
+- **Form** — Click **Select content**, browse the content, and select a Form content item to append it to the block.
 
 !!! caution "Known limitation"
 
@@ -181,7 +181,7 @@ On the **Properties** tab, set values in the following fields:
 - **Folder** — Click **Select content**, browse the content, and select a folder containing images to display.
 
 After submitting the settings, all images in the folder are shown in the Gallery block.
-Selecting a folder containing Content items other than images results in displaying only a link to the folder where they are stored.
+Selecting a folder containing content items other than images results in displaying only a link to the folder where they are stored.
 
 ## Ibexa Connect block
 
@@ -231,7 +231,7 @@ On the **Properties** tab, set values in the following fields:
 
 ## Personalized block
 
-Showcases recommended Content items or products triggered by specific scenarios for end users.
+Showcases recommended content items or products triggered by specific scenarios for end users.
 Enhances user experience by suggesting tailored options for various situations.
 On the **Properties** tab, set values in the following fields:
 
@@ -317,9 +317,9 @@ Targeting block provides recommendation of content based on users related to the
 On the **Properties** tab, set values in the following fields:
 
 - **Name** – Enter a name for the page block.
-- **Select default content** — Click **Select content**, browse the content, and choose the default Content item to display when no priority rules are valid.
+- **Select default content** — Click **Select content**, browse the content, and choose the default content item to display when no priority rules are valid.
 - **Setup segment and content matching priority rules** — Select a Segment Group and a Segment,
-then click **Select content** and navigate to the Content item that you want to display for the selected group.
+then click **Select content** and navigate to the content item that you want to display for the selected group.
 
 The rules are checked in order, so when a user belongs to more than one Segment, the first rule applies.
 

--- a/docs/content_management/configure_ct_field_settings.md
+++ b/docs/content_management/configure_ct_field_settings.md
@@ -16,10 +16,10 @@ You can only create or modify content types when your [user Role](../permission_
 
 3\. If your application requires a more granular organization of Fields within a content type, click **+ Add** to add more sections.
 
-When you add a **Metadata** section, it is later presented as an additional tab in [Content item](content_items.md) editing screen.
+When you add a **Metadata** section, it is later presented as an additional tab in [content item](content_items.md) editing screen.
 You can use it for tags, product categories, and so on.
-When you add other sections, they are later presented as anchors in Content item editing screen.
-All sections are later presented as headers on the Content item details screen, the **View** tab.
+When you add other sections, they are later presented as anchors in content item editing screen.
+All sections are later presented as headers on the content item details screen, the **View** tab.
 
 4\. Add, reorder or remove Fields as required:
 
@@ -49,15 +49,15 @@ Depending on their type, Fields can have different combinations of the following
 --------|-----------|---|
 |Name|A user-friendly name that describes the Field, used in the interface. It can be up to 255 characters long and consist of letters, digits, spaces and special characters.|Required|
 |Identifier|An identifier for system use in configuration files, templates, or PHP code. It can be up to 50 characters long and can only contain lowercase letters, digits and underscores. Also used in name patterns for the content type.|Required|
-|Description|A detailed description of the Field. It is displayed next to it when the user edits the Content item.|Optional|
-|Required|Indicates whether a value of the Field is required for the Content item to be saved or published.|Optional|
+|Description|A detailed description of the Field. It is displayed next to it when the user edits the content item.|Optional|
+|Required|Indicates whether a value of the Field is required for the content item to be saved or published.|Optional|
 |Searchable|Indicates whether a value of the Field is included in the search.|Optional|
 |Translatable|Indicates whether a value of the Field can be translated.|Optional|
 |Can be a thumbnail|Indicates whether the Field can be a thumbnail.|Optional|
 
 ## Default configuration of pages
 
-The following settings control the behavior of Content items of [Page](../content_management/create_edit_pages.md) type. 
+The following settings control the behavior of content items of [Page](../content_management/create_edit_pages.md) type. 
 You modify them in the **Field definitions** section, the **Landing Page** Field.
 
 ### Block display
@@ -105,16 +105,16 @@ Field in a content type, you can decide:
 
 - which Content Tree location opens in the 
 [Content Browser](content_model.md#content-browser) when the user browses to a related 
-Content item 
-- whether relations can be to Content items of a specific type only, or any content type
+content item 
+- whether relations can be to content items of a specific type only, or any content type
 
 #### Relation starting location
 
 In the **Select starting Location** area, select from the available options:
 
-- **Default** - the starting location is automatically assigned to the default location in the tree of a created Content item.
+- **Default** - the starting location is automatically assigned to the default location in the tree of a created content item.
 - **Browse** - use to manually select the location from the Content Browser.
-- **Content location** - the starting location is the location of the Content item that is edited by the user. For example, if the user edits the Content item with the location `50`, it sets the starting location to this value with children under this location.
+- **Content location** - the starting location is the location of the content item that is edited by the user. For example, if the user edits the content item with the location `50`, it sets the starting location to this value with children under this location.
 - **Root default location** - use if you want the Content Browser to start at the defined location with only children available for selection.
 
 ![Select starting location](img/select_start_location.png "Selecting a starting location")

--- a/docs/content_management/content_items.md
+++ b/docs/content_management/content_items.md
@@ -1,18 +1,18 @@
 ---
-description: Content items are containers that Ibexa DXP uses to store content data.
+description: content items are containers that Ibexa DXP uses to store content data.
 ---
 
 # Content items
 
-A Content item is a single piece of content: an article, a blog post, an image, 
+A content item is a single piece of content: an article, a blog post, an image, 
 or a product.
-Each Content item has general characteristics, such as name and identifier. 
+Each content item has general characteristics, such as name and identifier. 
 It also contains [Fields](content_model.md#fields-and-field-types).
 These Fields will differ depending on what kind of content you are dealing with.
-An *article* Content item may consist of Fields such as *title*, *name*, *author*, *body*, *image*, *subscriber teaser*, etc.
-A *product* Content item may have *product name*, *category*, *price*, *size*, *color*, etc. as Fields.
+An *article* content item may consist of Fields such as *title*, *name*, *author*, *body*, *image*, *subscriber teaser*, etc.
+A *product* content item may have *product name*, *category*, *price*, *size*, *color*, etc. as Fields.
 
-In [[= product_name =]], you create Content items based on templated called [content types](content_model.md#content_types).
+In [[= product_name =]], you create content items based on templated called [content types](content_model.md#content_types).
 
 ## Access content in the UI
 

--- a/docs/content_management/content_model.md
+++ b/docs/content_management/content_model.md
@@ -1,11 +1,11 @@
 ---
-description: The Ibexa DXP content model relies on Content items that are based on predefined content types.
+description: The Ibexa DXP content model relies on content items that are based on predefined content types.
 ---
 
 # Content model
 
 At the heart of [[= product_name =]] is a repository that stores all content.
-In [[= product_name =]] everything is a Content item — not just the actual pages displayed in the website,
+In [[= product_name =]] everything is a content item — not just the actual pages displayed in the website,
 but also all media (images, videos, etc.) and User accounts.
 
 [[= product_name =]] lets you customize and adapt the content model depending on your needs and the type of website you create.
@@ -16,28 +16,28 @@ However, even a non-technical user can easily create or modify the content model
 
 ## Content types
 
-A **content type** is comparable to a pattern or a template on which you base [Content items](content_items.md).
-Whenever you create a new Content item, you must choose its content type.
+A **content type** is comparable to a pattern or a template on which you base [content items](content_items.md).
+Whenever you create a new content item, you must choose its content type.
 
-The content type defines what Fields are available in the Content item.
-A Content item may only contain the Fields that are defined in the content type.
+The content type defines what Fields are available in the content item.
+A content item may only contain the Fields that are defined in the content type.
 
 [[= product_name =]] allows you to create, edit, and delete content types and their Fields.
 A clean installation contains a few basic content types.
 
 ## Content items versus content types
 
-A [Content item](content_items.md) is an instance of a particular content type, in other words, a single object created based on a content type template.
+A [content item](content_items.md) is an instance of a particular content type, in other words, a single object created based on a content type template.
 
-When a Content item is created, it inherits the Fields from its content type.
-However, the values of the Fields (their "contents") are empty, and you need to fill them separately for each Content item.
-The Fields in a content type are only definitions. This means that they describe what Fields of what kinds will be present in a Content item, but as a rule they do not provide these Fields' values.
+When a content item is created, it inherits the Fields from its content type.
+However, the values of the Fields (their "contents") are empty, and you need to fill them separately for each content item.
+The Fields in a content type are only definitions. This means that they describe what Fields of what kinds will be present in a content item, but as a rule they do not provide these Fields' values.
 
-As a consequence, all Content items of the same content type will share the same set of Fields, but their Field values will be different.
+As a consequence, all content items of the same content type will share the same set of Fields, but their Field values will be different.
 
 For example, you need to store book information.
 You create a new content type called "Book" and add to it Fields such as Title, Author, Genre, ISBN, etc.
-Next, based on this content type, you can create any number of Content items.
+Next, based on this content type, you can create any number of content items.
 The empty Fields will be ready to be filled in with the information about each specific book:
 
 ![Content model diagram](img/content_model_diagram.png "Content model diagram")
@@ -54,13 +54,13 @@ e.g. Text line, Rich text, Email, Author list, Content relation, Map location, F
 
 **content types:**
 
-- A content type defines Fields that a Content item will be composed of.
+- A content type defines Fields that a content item will be composed of.
 - Every Field is modeled after a Field Type which defines the kind of data it contains.
 
 **Content Items:**
 
-- A Content item consists of a number of Fields.
-- Every Content item is based on a content type.
+- A content item consists of a number of Fields.
+- Every content item is based on a content type.
 
 **Fields and Field Types:**
 

--- a/docs/content_management/content_organization/classify_content.md
+++ b/docs/content_management/content_organization/classify_content.md
@@ -11,7 +11,7 @@ a number of mechanisms that you can use.
 
 You can divide your Content Tree into Sections to better organize it.
 Sections let you decide which Users will have access to which parts of the tree.
-To see which Section a Content item belongs to, [disable the Focus mode](../../getting_started/discover_ui.md#disable-focus-mode), and look at its **Technical details** tab.
+To see which Section a content item belongs to, [disable the Focus mode](../../getting_started/discover_ui.md#disable-focus-mode), and look at its **Technical details** tab.
 
 You can set up Sections by navigating to **Content** -> **Sections**.
 A few Sections are provided with each installation, and you can add new ones.
@@ -21,15 +21,15 @@ A few Sections are provided with each installation, and you can add new ones.
 In the **Sections** tab, you can assign Sections to content or delete them.
 You can only delete Sections that do not contain any content.
 
-Each Content item must belong to a Section. By default, new content is placed in the same Section as its parent.
-If you want to remove a Content item from a Section, you just need to assign it to a different one.
+Each content item must belong to a Section. By default, new content is placed in the same Section as its parent.
+If you want to remove a content item from a Section, you just need to assign it to a different one.
 
 Access to Sections can be restricted by [setting up proper permissions](../../permission_management/work_with_permissions.md).
 
 ## Object states
 
-You can assign specific Object states to all Content items in your website.
-To do it, [disable the Focus mode](../../getting_started/discover_ui.md#disable-focus-mode), go to the Content item details view, and make necessary changes in the **Object state details** section.
+You can assign specific Object states to all content items in your website.
+To do it, [disable the Focus mode](../../getting_started/discover_ui.md#disable-focus-mode), go to the content item details view, and make necessary changes in the **Object state details** section.
 
 ![Object state details](img/object_state_details.png)
 
@@ -40,7 +40,7 @@ To do it, [disable the Focus mode](../../getting_started/discover_ui.md#disable-
 
 ## Bookmarks
 
-You can bookmark any Content item by clicking the star icon next to the Content name.
+You can bookmark any content item by clicking the star icon next to the Content name.
 
 ![Bookmark icon](img/bookmark_icon.png)
 

--- a/docs/content_management/content_organization/copy_move_hide_content.md
+++ b/docs/content_management/content_organization/copy_move_hide_content.md
@@ -1,29 +1,29 @@
 ---
-description: Copy, move, remove, or hide Content item, either individually or in bulk.
+description: Copy, move, remove, or hide content item, either individually or in bulk.
 ---
 
 # Copy, move or hide content
 
 ## Move or copy
 
-In Content Tree, you can move or copy existing Content items by selecting an 
+In Content Tree, you can move or copy existing content items by selecting an 
 option at the top of the screen.
-You can also copy the whole subtree (a Content item with all content under it in the structure).
+You can also copy the whole subtree (a content item with all content under it in the structure).
 
 !!! note
 
     Copying very large subtrees may take too much time and server effort. That is why the system administrator
-    may set a limit on how many Content items can be copied at the same time.
+    may set a limit on how many content items can be copied at the same time.
 
     See [Copy subtree limit]([[= developer_doc =]]/administration/back_office/back_office_configuration/#copy-subtree-limit)
     in the developer documentation on how to set this up.
 
-Copying creates a new Content item.
-If you only want to have the same Content item to another place in the Content Tree, add another Location to it.
+Copying creates a new content item.
+If you only want to have the same content item to another place in the Content Tree, add another Location to it.
 
 ### Multi-file move
 
-In the Content item's details screen, go to **Sub-items** tab, select multiple items, and click **Move**.
+In the content item's details screen, go to **Sub-items** tab, select multiple items, and click **Move**.
 Then choose a Location from the [content browser](../../getting_started/discover_ui.md#content-browser) in the **Choose Location** modal that opens up.
 After choosing and confirming new Location, all selected files are moved to it.
 
@@ -32,21 +32,21 @@ After choosing and confirming new Location, all selected files are moved to it.
 ## Remove content
 
 You can remove content by clicking **Send to Trash** in the menu.
-If you remove a Content item that has children (other content under it in the content tree),
+If you remove a content item that has children (other content under it in the content tree),
 both this item and the children will be removed. This also breaks the connection between the items,
 so you will not be able to restore them with the same structure.
 
-Notice that the Content item is not removed completely.
+Notice that the content item is not removed completely.
 It is moved to Trash, which you can access from the left menu.
-In the Trash, you can search for Content items and sort your search results based on different criteria. You can then select removed Content items and restore them to their original Locations or to new Locations you choose.
-If the Content item's parent has been removed, you need to select a new parent Location.
+In the Trash, you can search for content items and sort your search results based on different criteria. You can then select removed content items and restore them to their original Locations or to new Locations you choose.
+If the content item's parent has been removed, you need to select a new parent Location.
 
 ![Warning before emptying the trash](img/empty_trash_warning.png "Warning before emptying the Trash")
 
-If a Content item has more than one Location, selecting **Send to Trash** will remove the Content item only from the current Location.
+If a content item has more than one Location, selecting **Send to Trash** will remove the content item only from the current Location.
 The content will appear in Trash only once you have removed the last Location.
 
-You can permanently remove a Content item by checking it and clicking the trash icon.
+You can permanently remove a content item by checking it and clicking the trash icon.
 You can also permanently remove all content from the Trash by clicking **Empty Trash**.
 
 !!! caution "Warning"
@@ -59,7 +59,7 @@ There are multiple ways to delete multiple items, for example:
 
 - in Content Tree, select multiple items.
 Then click the three dots menu and select **Delete**
-- in Content item's details screen, the **Sub-items** tab, select multiple items and click **Delete**
+- in content item's details screen, the **Sub-items** tab, select multiple items and click **Delete**
 
 Confirm your choice in the pop-up window with the **Send to trash** button. All selected files are moved to trash.
 
@@ -67,18 +67,18 @@ Confirm your choice in the pop-up window with the **Send to trash** button. All 
 
 ### Hide content
 
-You can hide a Content item by clicking **Hide** in the menu.
+You can hide a content item by clicking **Hide** in the menu.
 
 ![Hide content icon](img/hide_content_icon.png)
 
 When you click **Hide**, you can choose to **Hide later**
-and select and date and time when the Content item will be hidden:
+and select and date and time when the content item will be hidden:
 
 ![Schedule hiding panel](img/schedule_hiding.png)
 
-A hidden Content item is not shown in the frontend when using the default templates. It is also grayed out in the Content Tree.
+A hidden content item is not shown in the frontend when using the default templates. It is also grayed out in the Content Tree.
 
-This is different from [hiding Locations](manage_locations_urls.md#hide-locations), because it affects the Content item
+This is different from [hiding Locations](manage_locations_urls.md#hide-locations), because it affects the content item
 in all of its Locations.
 
 !!! caution "Visibility and permissions"
@@ -87,7 +87,7 @@ in all of its Locations.
     It acts as a filter in the frontend by default. You can choose to respect it or ignore it in your code.
     It isn't permission-based, and **doesn't restrict access to content**. Hidden content can be read through other means, like the REST API.
 
-    If you need to restrict access to a given Content item, you could create a role that grants read access for a given
+    If you need to restrict access to a given content item, you could create a role that grants read access for a given
     [**Section**](https://doc.ibexa.co/projects/userguide/en/latest/content_management/content_organization/classify_content/#sections)
     or [**Object State**](https://doc.ibexa.co/projects/userguide/en/latest/content_management/content_organization/classify_content/#object-states),
     and set a different Section or Object State for the given Content.

--- a/docs/content_management/content_organization/manage_locations_urls.md
+++ b/docs/content_management/content_organization/manage_locations_urls.md
@@ -6,21 +6,21 @@ description: Manage the content of your website by controlling Locations and URL
 
 ## Content Locations
 
-A Content item by itself does not have a place in the Content Tree and is not visible for a visitor of the website.
+A content item by itself does not have a place in the Content Tree and is not visible for a visitor of the website.
 To be available on the website, it has to be assigned a Location ID.
-A new Content item is automatically assigned a Location when you publish it.
+A new content item is automatically assigned a Location when you publish it.
 
-A Content item can have more than one Location ID. In such a case you can find it in more than one place in the Content Tree.
-A single Location can only have one Content item in it.
+A content item can have more than one Location ID. In such a case you can find it in more than one place in the Content Tree.
+A single Location can only have one content item in it.
 
 !!! tip "Example"
 
     You can use multiple Locations for an Article about a local sports team's victory,
     which you can place in the tree both under Local News and Sports News.
 
-Even if a Content item is placed in more than one Location, one of the Locations is always treated as the main one.
+Even if a content item is placed in more than one Location, one of the Locations is always treated as the main one.
 
-To assign other Locations to content, [disable the Focus mode](../../getting_started/discover_ui.md#disable-focus-mode), go to this Content item's **Locations** tab and click **+ Add**.
+To assign other Locations to content, [disable the Focus mode](../../getting_started/discover_ui.md#disable-focus-mode), go to this content item's **Locations** tab and click **+ Add**.
 Then select the new parent from the Content Browser.
 
 ![Content with two locations](img/content_with_two_locations.png "Content with two Locations")
@@ -28,12 +28,12 @@ Then select the new parent from the Content Browser.
 ### Hide Locations
 
 You can manage the availability of content by hiding or revealing it.
-You can do this in the Content item's **Locations** tab by using the Visibility switcher.
+You can do this in the content item's **Locations** tab by using the Visibility switcher.
 Notice that this way only affects a *Location*, not the *Content item*.
 Even if you hide the content in one Location, it remains visible in its other Locations.
-You can also [hide the Content item itself](copy_move_hide_content.md#hide-content).
+You can also [hide the content item itself](copy_move_hide_content.md#hide-content).
 
-When a Location is hidden, all of its children (other Content items that are under it in the tree) will also be automatically hidden.
+When a Location is hidden, all of its children (other content items that are under it in the tree) will also be automatically hidden.
 They can only be revealed if the parent Location is revealed as well.
 
 A hidden Location will be invisible for everyone viewing the website.
@@ -42,21 +42,21 @@ use [Sections](classify_content.md#sections) and combine them with [proper permi
 
 ### Swap Locations
 
-You can swap two Content items in their Locations by going to the **Swap Locations** section
-in the **Location** tab and selecting a Content item to swap with.
+You can swap two content items in their Locations by going to the **Swap Locations** section
+in the **Location** tab and selecting a content item to swap with.
 
 !!! caution
 
     Swapping Locations republishes their respective URL aliases.
-    This means that if the swapped Content item was accessible by the URL that had a number at the end
+    This means that if the swapped content item was accessible by the URL that had a number at the end
     (added due to a name conflict), then after the swap the number will be removed (if possible).
     The opposite case also applies.
 
-    Swapping Locations for Content item with the same name and parent results in swapping their URL aliases.
-    This means that if the Content item was previously accessible by a URL without a number at the end,
+    Swapping Locations for content item with the same name and parent results in swapping their URL aliases.
+    This means that if the content item was previously accessible by a URL without a number at the end,
     after the swap it will be accessible by a URL with a number at the end (and the other way around).
 
-    If at some point there were more than two Content items with the same name under the same parent, then result of swapping such Content items might not be obvious. The general rule is that the Content item that previously had a higher number at the end of its URL alias will have its URL alias republished first, resulting in the lowest nonconflicting number (or the lack of) at the end of its URL alias. The Content item that previously had a lower number at the end of its URL alias will have its URL alias republished second, resulting in the second lowest nonconflicting number at the end of its URL alias.
+    If at some point there were more than two content items with the same name under the same parent, then result of swapping such content items might not be obvious. The general rule is that the content item that previously had a higher number at the end of its URL alias will have its URL alias republished first, resulting in the lowest nonconflicting number (or the lack of) at the end of its URL alias. The content item that previously had a lower number at the end of its URL alias will have its URL alias republished second, resulting in the second lowest nonconflicting number at the end of its URL alias.
 
 ## URL management
 
@@ -68,15 +68,15 @@ For more information about URL management, see the [Ibexa Developer Documentatio
 ### Link manager
 
 In your website you can link to external websites by placing links inside rich text, or by using the URL Field.
-You can view and update all external links that exist within the website, without having to modify and re-publish the individual Content items.
+You can view and update all external links that exist within the website, without having to modify and re-publish the individual content items.
 
 ![Link manager tab](img/Link_manager_sm.png)
 
-The Link manager tab shows a list of all links in the website. Click any item in the list to see its details and a list of Content items that use this URL.
+The Link manager tab shows a list of all links in the website. Click any item in the list to see its details and a list of content items that use this URL.
 
 ![Detail of a link in Link manager](img/link_manager_detail.png)
 
-You can change any link in the Link manager. It is then updated in every place where it is used, across all Content items.
+You can change any link in the Link manager. It is then updated in every place where it is used, across all content items.
 
 The Link manager list also shows whether the link is alive or dead in the **Status** column. The **Last checked** column displays when the status was last verified.
 
@@ -88,7 +88,7 @@ The Link manager list also shows whether the link is alive or dead in the **Stat
 
 ### URL aliases
 
-Each Content item can have one or more URL aliases. They are additional URLs that can be used to access this Content item.
+Each content item can have one or more URL aliases. They are additional URLs that can be used to access this content item.
 
 To add URL aliases, go to the **URL** tab, and click **+ Add** in the **Custom URL aliases for...** area.
 The URL alias must be unique for the whole installation, regardless of the language.
@@ -97,15 +97,15 @@ The URL alias must be unique for the whole installation, regardless of the langu
 
 For each new alias, you can set the following options:
 
-- Language - the language of the Content item that the alias redirects to.
-- Redirect to alias destination - when toggled on, the alias will redirect to the Content item's actual URL.
+- Language - the language of the content item that the alias redirects to.
+- Redirect to alias destination - when toggled on, the alias will redirect to the content item's actual URL.
 - Place at the website root - when toggled, the alias will be created in the root of the website.
-If this is toggled off, the alias will be relative to the parent of the Content item.
+If this is toggled off, the alias will be relative to the parent of the content item.
 - SiteAccess - when selected, the prefix of the respective SiteAccess is added to the alias path.
 
 ### URL wildcards
 
-With wildcards, you can replace a portion of the URL address for many Content items at the same time, for example, to shorten the path, or to make the path meaningful for the readers.
+With wildcards, you can replace a portion of the URL address for many content items at the same time, for example, to shorten the path, or to make the path meaningful for the readers.
 
 ![URL wildcards tab](img/URL_Wildcards_sm.png)
 

--- a/docs/content_management/content_versions.md
+++ b/docs/content_management/content_versions.md
@@ -1,37 +1,37 @@
 ---
-description: Learn about Content item versions and the Autosave feature.
+description: Learn about content item versions and the Autosave feature.
 ---
 
 # Content versions
 
 ## Types of content versions
 
-In [[= product_name =]], Content items can have more than one version.
+In [[= product_name =]], content items can have more than one version.
 Versions can be of published, archived, or draft type.
 
 The **published version** is the version that is currently presented to the audience.
-Every Content item can have only one published version at a time.
+Every content item can have only one published version at a time.
 
-Whenever you edit and publish a Content item again, its previous published version becomes an **archived version**.
+Whenever you edit and publish a content item again, its previous published version becomes an **archived version**.
 It is not available to the visitor and you cannot edit it, but you can create new drafts based on any archived version.
 
 Finally, **drafts** are versions that have not been published yet.
-There can be many drafts of the same Content item.
+There can be many drafts of the same content item.
 They can be created by the autosave feature, by the reviewer as part of the 
 [editorial workflow](workflow_management/editorial_workflow.md), or when you save
-the work and close the Content item editing screen.
+the work and close the content item editing screen.
 
-You can view all versions of a Content item on the Content item details screen.
-To do it, [disable the Focus mode](../getting_started/discover_ui.md#disable-focus-mode), and go to this Content item's **Versions** tab.
+You can view all versions of a content item on the content item details screen.
+To do it, [disable the Focus mode](../getting_started/discover_ui.md#disable-focus-mode), and go to this content item's **Versions** tab.
 
-![All versions of a Content item](img/content_item_versions.png "All versions of a Content item")
+![All versions of a content item](img/content_item_versions.png "All versions of a content item")
 
 For more information, see [Editorial workflow](workflow_management/editorial_workflow.md) and [Work with versions](work_with_versions.md).
 
 ### Autosave
 
-While you edit a Content item or product, [[= product_name =]] saves your work automatically to help you preserve the progress in an event of a failure.
-To recover your work, [disable the Focus mode](../getting_started/discover_ui.md#disable-focus-mode), go to this Content item's **Versions** tab, and open the most recent draft.
+While you edit a content item or product, [[= product_name =]] saves your work automatically to help you preserve the progress in an event of a failure.
+To recover your work, [disable the Focus mode](../getting_started/discover_ui.md#disable-focus-mode), go to this content item's **Versions** tab, and open the most recent draft.
 Alternatively, open the most recent draft of your work on the **My dashboard** page, the **Drafts** table.
 
 Autosave is enabled by default, and set to save a draft every 60 seconds.

--- a/docs/content_management/create_edit_content_items.md
+++ b/docs/content_management/create_edit_content_items.md
@@ -2,39 +2,39 @@
 description: Create content for your website with different Fields, rich text, tags, and then publish it.
 ---
 
-# Create and edit Content items
+# Create and edit content items
 
-## Create Content items
+## Create content items
 
-1. Start creating a new Content item in one of the following ways:
+1. Start creating a new content item in one of the following ways:
 
-    - In the left panel, go to **Content** -> **Content structure**. Then select a parent Content item and click **Create content**. 
+    - In the left panel, go to **Content** -> **Content structure**. Then select a parent content item and click **Create content**. 
     
-        The new Content item becomes a child of the Content item that you originally selected.
+        The new content item becomes a child of the content item that you originally selected.
     
     - In the upper-right corner of the [My dashboard](../getting_started/discover_ui.md#my-dashboard) screen, click **Create content**.
     Then choose a location for the new item in [Content Browser](../getting_started/discover_ui.md#content-browser) and click **Create**.
 
     !!! tip
 
-        An alternative way of creating Content items is to [drag one or more files](#upload-multiple-content-items) onto the **Sub-items** tab when viewing any Content item in a [Content Tree](../getting_started/discover_ui.md#content-tree). 
+        An alternative way of creating content items is to [drag one or more files](#upload-multiple-content-items) onto the **Sub-items** tab when viewing any content item in a [Content Tree](../getting_started/discover_ui.md#content-tree). 
 
 1. In a slide-out pane, make initial choices in the following fields, and click **Create**:
 
-    - **Select a language** - from a drop-down list, select the base language for the Content item.
-    - **Select a content type** - use this field to narrow down the list of choices displayed below. Then select a content type to serve as a template for the Content item.
+    - **Select a language** - from a drop-down list, select the base language for the content item.
+    - **Select a content type** - use this field to narrow down the list of choices displayed below. Then select a content type to serve as a template for the content item.
 
     !!! note
        
         If you're using [[= product_name_exp =]] or [[= product_name_com =]], the options include forms and pages.
         You then [build forms](work_with_forms.md) and [create pages](create_edit_pages.md) by using their respective specialist tools.
 
-1. [Fill in the Fields](#edit-new-or-existing-content-items) of the Content item.
+1. [Fill in the Fields](#edit-new-or-existing-content-items) of the content item.
 
-1. Click **Preview** to see how the Content item could look to an end-user.
+1. Click **Preview** to see how the content item could look to an end-user.
     !!! tip
     
-        A Content item can look different on different [SiteAccesses](translate_content.md#siteaccess).
+        A content item can look different on different [SiteAccesses](translate_content.md#siteaccess).
         You can select a SiteAccess to preview by using a drop-down in the preview screen.
 
 1. To discard your changes and close the window, click **Delete draft**.
@@ -46,7 +46,7 @@ description: Create content for your website with different Fields, rich text, t
 
 1. To send your changes to another editor [for review](editorial_workflow.md), click **Send to review**. 
 
-1. When the Content item is ready for publication:
+1. When the content item is ready for publication:
 
     - Click **Publish** to publish it immediately.
     - Click **Publish later** to set a specific publication date.
@@ -55,17 +55,17 @@ description: Create content for your website with different Fields, rich text, t
 
 !!! note "Versioning and autosave"
 
-    Whenever you edit a Content item, a [new version](content_versions.md) is created in the repository.
+    Whenever you edit a content item, a [new version](content_versions.md) is created in the repository.
 
-    To help you preserve your work, [[= product_name =]] saves drafts of Content items automatically.
+    To help you preserve your work, [[= product_name =]] saves drafts of content items automatically.
     For more information, see [Autosave](content_versions.md#autosave).
 
-##### Upload multiple Content items
+##### Upload multiple content items
 
-When you view the Content item details in the Content Tree, you can upload files such as images, videos, PDF documents, and so on.
-This way you can add multiple sub-items without editing the original Content item.
-To do it, on the Content item details screen, in the **Sub-items** tab, click **Upload** and choose all items that you want to upload.
-When a file is uploaded with multi-file upload, it is automatically stored in a Field of the Content item.
+When you view the content item details in the Content Tree, you can upload files such as images, videos, PDF documents, and so on.
+This way you can add multiple sub-items without editing the original content item.
+To do it, on the content item details screen, in the **Sub-items** tab, click **Upload** and choose all items that you want to upload.
+When a file is uploaded with multi-file upload, it is automatically stored in a Field of the content item.
 
 !!! note
 
@@ -73,24 +73,24 @@ When a file is uploaded with multi-file upload, it is automatically stored in a 
 
 ![Multi-file upload](img/multi_file_upload.png)
 
-## Edit new or existing Content items
+## Edit new or existing content items
 
-Each Content item is based on a [content type](create_edit_content_types.md). The content type defines what Fields 
+Each content item is based on a [content type](create_edit_content_types.md). The content type defines what Fields 
 you have to fill in when creating a new item.
 It may also determine the layout or style in which this item is displayed.
 
 Fields marked with an asterisk (\*) are required. 
-You can't save the Content item without filling them in.
+You can't save the content item without filling them in.
 
-Some Fields, such as *Relation* Fields (which link two Content items) or *Image* Fields
-require you to select a different Content item to link to.
+Some Fields, such as *Relation* Fields (which link two content items) or *Image* Fields
+require you to select a different content item to link to.
 A *Location* Field is a point on the map. You can type the place name, enter its coordinates, or select it on the map.
 
 <a name="relation_field"></a>
 
 !!! note
 
-    When you create or edit a Content item that contains an *Image* or an *Image asset* Field, 
+    When you create or edit a content item that contains an *Image* or an *Image asset* Field, 
     you can perform basic image editing functions by using an [Image Editor](../image_management/edit_images.md).
 
 ### Edit Rich Text Fields
@@ -117,26 +117,26 @@ To add a new element to the Field, choose one of the available elements:
 Each of these elements can have its own settings, such as text formatting.
 The option bar also lets you reorder or remove any elements in the Rich Text Field.
 
-#### Edit embedded Content items
+#### Edit embedded content items
 
-You can edit embedded Content items without leaving current window.
+You can edit embedded content items without leaving current window.
 
-To do it, first insert selected Content item in the Rich Text Field.
+To do it, first insert selected content item in the Rich Text Field.
 Then, click the three dots icon on the right side and click **Edit**.
 
-![Edit embedded Content item](img/edit_embedded_item_richtext.png "Edit embedded Content item")
+![Edit embedded content item](img/edit_embedded_item_richtext.png "Edit embedded content item")
 
-If the Content item has more than one translation available, you need to select the language.
+If the content item has more than one translation available, you need to select the language.
 
-![Edit embedded Content item - select language](img/edit_embedded_item_language_richtext.png "Edit embedded Content item - select language")
+![Edit embedded content item - select language](img/edit_embedded_item_language_richtext.png "Edit embedded content item - select language")
 
-This action opens a new browser tab with an editing screen of the selected Content item.
+This action opens a new browser tab with an editing screen of the selected content item.
 When you finish editing the item, click **Publish**.
 To see implemented changes refresh the browser page.
 
-This option is also available when you want to set up a [relation](configure_ct_field_settings.md#content-relation-settings) with another Content item.
+This option is also available when you want to set up a [relation](configure_ct_field_settings.md#content-relation-settings) with another content item.
 
-![Edit embedded Content item - set up a relation](img/edit_embedded_items_relation.png "Edit embedded Content item - set up a relation")
+![Edit embedded content item - set up a relation](img/edit_embedded_items_relation.png "Edit embedded content item - set up a relation")
 
 #### Distraction free mode
 
@@ -195,11 +195,11 @@ For more information, see [SeenThis! page block](block_reference.md#seenthis-blo
 ### Text formatting
 
 When you select a section of text, you get access to text formatting options such as bold or underline.
-Here you can also add a link to the text. You can link to an external website, or to another Content item.
+Here you can also add a link to the text. You can link to an external website, or to another content item.
 
 ### Add taxonomy entries
 
-To keep your content organized and easy to find, you can add taxonomy entries to a Content item while creating or editing it.
+To keep your content organized and easy to find, you can add taxonomy entries to a content item while creating or editing it.
 For this feature to work as described, the content type must have a **Metadata** section, with a **Taxonomy Entry** field in it.
 
 1. Switch to the **Meta** tab.

--- a/docs/content_management/create_edit_content_types.md
+++ b/docs/content_management/create_edit_content_types.md
@@ -1,17 +1,17 @@
 ---
-description: Create or edit content types by listing Fields that make a Content item.
+description: Create or edit content types by listing Fields that make a content item.
 ---
 
 # Create and edit content types
 
-[Content types](content_model.md#content-types) define what Fields are available in [Content items](content_items.md). 
+[Content types](content_model.md#content-types) define what Fields are available in [content items](content_items.md). 
 To suit your specific needs, you can modify the default content types, or add custom ones.
 
 You can only create or modify content types when your [user Role](../permission_management/work_with_permissions.md) has the `ContentType/Create` or `ContentType/Update` permission.
 
-When you edit a content type, each Content item based on this content type changes.
+When you edit a content type, each content item based on this content type changes.
 For example, when you add or remove a Field to the content type, the change 
-is propagated to every Content item of this type.
+is propagated to every content item of this type.
 
 !!! note
 
@@ -25,8 +25,8 @@ is propagated to every Content item of this type.
 
 !!! caution "Deleting content types"
 
-    You can delete a content type only when there are no Content items that belong to it.
-    This also includes Content items in the Trash.
+    You can delete a content type only when there are no content items that belong to it.
+    This also includes content items in the Trash.
 
 1\. In the left panel, go to **Content** -> **Content types**. Then select a content type group by clicking its name, for example, **Content**.
 
@@ -48,9 +48,9 @@ is propagated to every Content item of this type.
 --------|-----------|---|
 |Name|A name of the content type.|Required|
 |Identifier|A unique identifier of the content type in the system. Up to 50 characters and can only consist of letters, numbers and underscores.|Required|
-|Description|Additional information that is displayed when a Content item is created based on this type.|Optional|
-|Content name pattern|Rules for creating a name for the Content item.|Optional|
-|URL alias name pattern|Rules for creating the URL alias for a Content item.|Optional|
+|Description|Additional information that is displayed when a content item is created based on this type.|Optional|
+|Content name pattern|Rules for creating a name for the content item.|Optional|
+|URL alias name pattern|Rules for creating the URL alias for a content item.|Optional|
 |Container|When checked, Content of this Type can serve as a container in the Content Tree.|Optional|
 |Sort children by default by|Criterion by which children of this content are sorted in the tree.|Required if **Container** is checked|
 |Sort children by default in order|Order in which the children are sorted (ascending or descending).|Required if **Container** is checked|
@@ -60,7 +60,7 @@ is propagated to every Content item of this type.
 
     When populating the patterns, you can use a schema with attributes which 
     correspond to the identifiers of Fields that make up the content type. 
-    This way, when Content Items of this type are created, their names and URL 
+    This way, when content items of this type are created, their names and URL 
     aliases are generated according to the defined pattern. 
 
     For example, if you enter `<short_title>` as a value of the **Content name 

--- a/docs/content_management/create_edit_pages.md
+++ b/docs/content_management/create_edit_pages.md
@@ -15,14 +15,14 @@ Whenever you edit a Page, a [new version](content_versions.md) is created in the
 !!! tip
     The Page content type contains a **Landing Page** Field Type which manages
     the zones and blocks.
-    Any Content item that has the **Landing Page** Field Type behaves like
+    Any content item that has the **Landing Page** Field Type behaves like
     a page.
 
 ## Create Page
 
-1. In the left panel, go to **Content** -> **Content structure**. Then select a parent Content item and click **Create content**.
+1. In the left panel, go to **Content** -> **Content structure**. Then select a parent content item and click **Create content**.
 1. In a slide-out pane, make initial choices in the following fields, and click **Create**:
-    - **Select a language** - from a drop-down list, select the base language for the Content item.
+    - **Select a language** - from a drop-down list, select the base language for the content item.
     - **Select a content type** - use this field to narrow down the list of content type choices displayed below. Then select one of page type, for example, **Landing Page**, and click the **Create** button.
 1. In the [Page Builder toolbar](#page-builder-toolbar) click **Fields** and define the page's title and description.
 1. Click  **Switch layout** and select the layout.
@@ -39,7 +39,7 @@ You can now navigate away from the Page by clicking the **Close** button.
 
 !!! note "Autosave"
 
-    To help you preserve your work, [[= product_name =]] saves drafts of Content items automatically.
+    To help you preserve your work, [[= product_name =]] saves drafts of content items automatically.
     For more information, see [Autosave](content_versions.md#autosave).
 
 ## Edit Page
@@ -196,20 +196,20 @@ After you change the block settings, click **Submit** to save the changes or **D
 
 #### Edit embedded items
 
-You can edit embedded Content items without leaving Page Builder.
+You can edit embedded content items without leaving Page Builder.
 
-To do it, first select Content item that you want to insert in the block.
+To do it, first select content item that you want to insert in the block.
 Then, click the icon on the right side and click **Edit**.
 
-![Edit embedded Content item](img/edit_embedded_content_item.png "Edit embedded Content item")
+![Edit embedded content item](img/edit_embedded_content_item.png "Edit embedded content item")
 
-This action opens a new tab in the browser with an editing screen of the selected Content item.
+This action opens a new tab in the browser with an editing screen of the selected content item.
 When you finish editing the item, click **Publish** and go back to Page Builder tab.
-All the Content item details automatically update in the block window.
+All the content item details automatically update in the block window.
 
-If the Content item has more than one translation available, you need to select the language.
+If the content item has more than one translation available, you need to select the language.
 
-![Edit embedded Content item - select language](img/edit_item_select_language.png "Edit embedded Content item - select language")
+![Edit embedded content item - select language](img/edit_item_select_language.png "Edit embedded content item - select language")
 
 This function is available for following blocks:
 
@@ -251,4 +251,4 @@ There are several options for saving work on the page:
 |Save draft|Save the page draft*.|
 |Delete draft|Delete the page draft.|
 
-* To help you preserve your work, system saves drafts of Content items automatically. For more information, see [Autosave](https://doc.ibexa.co/projects/userguide/en/master/content_management/content_versions/#autosave).
+* To help you preserve your work, system saves drafts of content items automatically. For more information, see [Autosave](https://doc.ibexa.co/projects/userguide/en/master/content_management/content_versions/#autosave).

--- a/docs/content_management/preview_content_items.md
+++ b/docs/content_management/preview_content_items.md
@@ -2,9 +2,9 @@
 description: Preview content items of various types in many places of the Back Office.
 ---
 
-# Preview Content items
+# Preview content items
 
-There are several places where you can see how the Content item could look to an end-user.
+There are several places where you can see how the content item could look to an end-user.
 The system behaves differently depending on whether you are in [Focus mode](../getting_started/discover_ui.md#focus-mode) or not and whether you selected a specific site from the **Site context** drop-down list in the top bar.
 
 - When you [edit a Page](create_edit_content_items.md), the editor provides a visual experience.
@@ -15,18 +15,18 @@ By clicking the following icons, you can switch between different Page views.
 |![Preview segments](page_builder_toolbar_preview_segment.png)|Access preview of the Page for a given [segment](content_organization/classify_content.md#segments).|
 |![Timeline button](page_builder_toolbartimelinetoggler.png)|Access the timeline to preview how the Page changes with time. You can also view the list of all upcoming scheduled events.|
 
-- When you [edit a Content item](create_edit_content_items.md), click **Preview**
-- In the Content item's details screen, click **Preview**
+- When you [edit a content item](create_edit_content_items.md), click **Preview**
+- In the content item's details screen, click **Preview**
 
 !!! tip
 
-    In the Content item preview screen, you can use a drop-down list to change site context by switching between [SiteAccesses](translate_content.md#siteaccess).
-    You can also toggle through different screen widths to see how the Content item is rendered on different devices.
+    In the content item preview screen, you can use a drop-down list to change site context by switching between [SiteAccesses](translate_content.md#siteaccess).
+    You can also toggle through different screen widths to see how the content item is rendered on different devices.
 
 ![View toggler](page_builder_toolbar_devicestoggler.png "View toggler")
 
 Additionally, if you select a specific SiteAccess from the **Site context** drop-down list in the top bar, three things happen:
 
-- when you hover over Content items in the Content Tree, miniature previews appear
-- in Focus mode, when you browse Content items in Content Tree, their full screen preview is displayed
-- if you [disable the Focus mode](../getting_started/discover_ui.md#disable-focus-mode) or click **Exit full view**, the **View** tab appears in the Content item's details view, where you can quickly preview the Content item
+- when you hover over content items in the Content Tree, miniature previews appear
+- in Focus mode, when you browse content items in Content Tree, their full screen preview is displayed
+- if you [disable the Focus mode](../getting_started/discover_ui.md#disable-focus-mode) or click **Exit full view**, the **View** tab appears in the content item's details view, where you can quickly preview the content item

--- a/docs/content_management/publish_instantly.md
+++ b/docs/content_management/publish_instantly.md
@@ -1,23 +1,23 @@
 ---
-description: You can instantly publish a newly created Content item or save its draft for editing.
+description: You can instantly publish a newly created content item or save its draft for editing.
 ---
 
 # Publish content instantly
 
-When you publish a Content item, it is given a Location ID and placed in the Content Tree.
-After you click **Publish**, the Content item is validated and if any of the required
+When you publish a content item, it is given a Location ID and placed in the Content Tree.
+After you click **Publish**, the content item is validated and if any of the required
 Fields are not configured, you see a notification.
-Once the Content item passes the validation, it is immediately available to the visitor.
+Once the content item passes the validation, it is immediately available to the visitor.
 
-Instead of instantly publishing Content items, you can also save them, discard changes by deleting the draft, or [publish later](schedule_publishing.md#date-based-publishing).
-If you are creating a new Content item, you can also [send it to review](editorial_workflow.md).
+Instead of instantly publishing content items, you can also save them, discard changes by deleting the draft, or [publish later](schedule_publishing.md#date-based-publishing).
+If you are creating a new content item, you can also [send it to review](editorial_workflow.md).
 All these options are available in the menu when you are in the edit mode.
 
 ![Publishing options](img/publishing_options.png "Publishing options")
 
 ### Publishing vs. saving
 
-Clicking **Save** does not immediately publish the Content item.
+Clicking **Save** does not immediately publish the content item.
 Instead, it saves the [new version](content_versions.md) of the content as a draft.
 You can then keep on editing the same content and save it again when needed,
 or click **Save and close** to close the window.
@@ -28,8 +28,8 @@ or click **Save and close** to close the window.
     A discarded draft is removed instantly, not placed in the Trash, so it can't be restored.
 
 Once you leave the editor after saving your draft, you can return to modify it, or create a new draft.
-To edit an existing draft, [disable the Focus mode](../getting_started/discover_ui.md#disable-focus-mode), go to this Content item's **Versions** tab and click the edit icon in the proper line.
-When you select **Edit** in a Content item that has one or more open drafts,
+To edit an existing draft, [disable the Focus mode](../getting_started/discover_ui.md#disable-focus-mode), go to this content item's **Versions** tab and click the edit icon in the proper line.
+When you select **Edit** in a content item that has one or more open drafts,
 you are asked which draft you want to continue working on.
 You also have the option to create a new draft based on the currently published version.
 

--- a/docs/content_management/schedule_publishing.md
+++ b/docs/content_management/schedule_publishing.md
@@ -21,26 +21,26 @@ This way you can see what content is planned will be available in the future.
 
 ## Content Scheduler block [[% include 'snippets/experience_badge.md' %]] [[% include 'snippets/commerce_badge.md' %]]
 
-In the Content Scheduler block you can select Content items to be displayed at a selected time.
+In the Content Scheduler block you can select content items to be displayed at a selected time.
 
-For each Content item you can choose an airtime - a date and time in the future.
-At this time the Content item will become visible.
+For each content item you can choose an airtime - a date and time in the future.
+At this time the content item will become visible.
 
-The Content Scheduler block has a limit of Content items.
-If the limit is filled and a new Content item is displayed, the oldest item will disappear from the block.
+The Content Scheduler block has a limit of content items.
+If the limit is filled and a new content item is displayed, the oldest item will disappear from the block.
 
 ![Content Scheduler](img/content_scheduler.png)
 
 ## Date-based publishing
 
-When editing a Content item, select **Publish later** in the menu on the right.
+When editing a content item, select **Publish later** in the menu on the right.
 
 ![Publish Later button in the menu](img/publish_later.png "Publish Later button in the menu")
 
 A **Future publication settings** window is displayed.
 Choose a date and time and the content will be published at that time.
 
-If you had planned a future publication date and enter the edit mode of the same Content item,
+If you had planned a future publication date and enter the edit mode of the same content item,
 you also have a new option in the menu: **Discard publish later**.
 Use it to remove the previously selected publication date.
 
@@ -51,14 +51,14 @@ To browse all the future events, use the [Calendar widget](#calendar-widget).
 
 ## Date-based hiding
 
-When your Content item is published, you can schedule a date and time and the content will be hidden at that time.
+When your content item is published, you can schedule a date and time and the content will be hidden at that time.
 To do this, go to the **Content** tab and select **Content structure** or **Media**.
-Then, navigate to the Content item that you want to hide and click **Hide** in the menu.
+Then, navigate to the content item that you want to hide and click **Hide** in the menu.
 
-![Hide Content item modal window](content_organization/img/schedule_hiding.png "Hide Content item modal window")
+![Hide content item modal window](content_organization/img/schedule_hiding.png "Hide content item modal window")
 
-Once a Content item is hidden, it is unavailable on the front page and inactive in the Content Tree.
-This change affects the Content item in all of its [Locations](content_organization/manage_locations_urls.md#content-locations).
+Once a content item is hidden, it is unavailable on the front page and inactive in the Content Tree.
+This change affects the content item in all of its [Locations](content_organization/manage_locations_urls.md#content-locations).
 
 ## Timeline [[% include 'snippets/experience_badge.md' %]] [[% include 'snippets/commerce_badge.md' %]]
 
@@ -72,7 +72,7 @@ Use the button on the right of the time to see a list of all upcoming changes.
 ## Calendar widget
 
 The calendar widget enables you to view and perform actions on various events.
-Out of the box, it displays Content items and Page blocks scheduled for future publication, but your page administrator can configure custom events.
+Out of the box, it displays content items and Page blocks scheduled for future publication, but your page administrator can configure custom events.
 Therefore, the calendar can contain other events, e.g. national holidays, important dates, etc.
 
 To access the calendar widget, in the **Content Panel**, open the **Calendar** tab.
@@ -126,7 +126,7 @@ To select, click on all events of the same type you want to add to the toolbar l
 
 ## Reschedule or cancel publication
 
-In case of publishable Content items (e.g. articles), you can change or cancel their planned publication by clicking **Reschedule** or **Cancel publication**.
+In case of publishable content items (e.g. articles), you can change or cancel their planned publication by clicking **Reschedule** or **Cancel publication**.
 These buttons are available on the **My dashboard** screen, and in the Calendar widget.
 
 |Button|Description|
@@ -139,8 +139,8 @@ These buttons are available on the **My dashboard** screen, and in the Calendar 
 To reschedule or cancel events with the dashboard, perform the following actions:
 
 1. Open the **My dashboard** screen by clicking the logo in the left-upper corner.
-1. In **My content** panel, view all your scheduled Content items by clicking **My scheduled content**.
-1. From **My future publications**, select all Content items to have their publication time rescheduled or cancelled.
+1. In **My content** panel, view all your scheduled content items by clicking **My scheduled content**.
+1. From **My future publications**, select all content items to have their publication time rescheduled or cancelled.
 1. Using the buttons in the upper-right corner, perform one or both of the following actions:
     - To change the publication time, click **Reschedule**.
       In the **Reschedule** modal window, select the new date and click **Confirm date change**.

--- a/docs/content_management/taxonomy/taxonomy.md
+++ b/docs/content_management/taxonomy/taxonomy.md
@@ -1,5 +1,5 @@
 ---
-description: Taxonomy is one of the ways classify Content items with structured tags.
+description: Taxonomy is one of the ways classify content items with structured tags.
 ---
 
 # Taxonomy
@@ -9,14 +9,14 @@ create relationships between items to make it easier for website users to find
 the content they need, or browse and view content appropriate for them. 
 
 Tag hierarchies (aka Taxonomies) are classifications of logical relationships 
-between Content items. 
+between content items. 
 In [[= product_name =]], you can create many taxonomies, each with a tree that 
 contains many tags. 
 
 ## Taxonomy tree
 
 Taxonomy tree is where you create a hierarchy of all tags and relationships between 
-tags and Content items.
+tags and content items.
 Working with the Taxonomy tree is similar to working with the Content structure tree.
 
 ![Taxonomy tree and tag details](img/taxonomy_content_list.png "Taxonomy tree and tag details")

--- a/docs/content_management/taxonomy/work_with_tags.md
+++ b/docs/content_management/taxonomy/work_with_tags.md
@@ -1,10 +1,10 @@
 ---
-description: Taxonomy is one of the ways classify Content items with structured tags.
+description: Taxonomy is one of the ways classify content items with structured tags.
 ---
 
 # Work with Tags
 
-Once you have created Content items that follow the structure defined within the 
+Once you have created content items that follow the structure defined within the 
 content model, you can create [taxonomies](taxonomy.md) that consist of tags, to help users find 
 the content they need.
 
@@ -32,9 +32,9 @@ To be able to assign tags to a Content, first, you need to add a Taxonomy Entry 
 1. Go to **Content types** -> **Content**.
 1. Click the **Edit** icon next to the content type you want to modify.
 1. Go to **Field definitions** and from the available options, drag and drop the **Taxonomy Entry Assignment** to fields in the content type.
-1. From the **Taxonomy** drop-down, select the taxonomy type you want to tag this Content item with.
+1. From the **Taxonomy** drop-down, select the taxonomy type you want to tag this content item with.
 
-Now, when you edit or create a Content item of this type, in the tags section, you can add a tag by clicking **Select Taxonomy Entries**. See [Add taxonomy entries](create_edit_content_items.md#add-taxonomy-entries).
+Now, when you edit or create a content item of this type, in the tags section, you can add a tag by clicking **Select Taxonomy Entries**. See [Add taxonomy entries](create_edit_content_items.md#add-taxonomy-entries).
 
 !!! caution "Duplicate taxonomy fields"
     Because tags are assigned per content item, not per Field, you cannot use two **Taxonomy Entry Assignment** Fields with the same taxonomy type in one content type.
@@ -58,9 +58,9 @@ You can delete tags directly from the taxonomy tree. Go to **Tags** section.
 
 ![Delete tag](img/taxonomy_delete_tag.png "Delete tag")
 
-### View all Content items with specific tag
+### View all content items with specific tag
 
-You can view a list of all Content items which are tagged with the given tag.
+You can view a list of all content items which are tagged with the given tag.
 To do it, go to **Tags** section.
 In the taxonomy tree click the respective tag and go to the **Content** tab.
 

--- a/docs/content_management/translate_content.md
+++ b/docs/content_management/translate_content.md
@@ -1,10 +1,10 @@
 ---
-description: Create multiple language versions of Content items.
+description: Create multiple language versions of content items.
 ---
 
 # Translate content
 
-The content on your website can be translated into different languages. Each Content item can have different language versions.
+The content on your website can be translated into different languages. Each content item can have different language versions.
 The version visible to a visitor depends on the way your installation is set up (see [SiteAccess concept](#edit-page-for-different-language-versions-of-a-website)).
 
 ## Add website languages
@@ -25,7 +25,7 @@ After adding a language, you may have to reload the application to be able to us
 
 ## Add translations
 
-1\. In the left panel, go to **Content** -> **Content structure**. Then select a Content item.
+1\. In the left panel, go to **Content** -> **Content structure**. Then select a content item.
 
 2\. Go to **Translations** tab and click **+ Add**.
 
@@ -37,18 +37,18 @@ If you do not choose a base translation, the Fields remain empty.
 While working, you can save your work and continue or click **Delete draft** to discard your changes.
 When done, you can save your work and close the window, publish the translated article immediately, or pick another publication date.
 
-Every time you add or edit a translation, a new version of the Content item is created,
+Every time you add or edit a translation, a new version of the content item is created,
 the same way as when editing only one language.
 
 ![Adding a new translation](img/adding_translation.png "Adding a new translation")
 
 ## Translation comparison
 
-You can compare different versions of the translations of the Content item.
+You can compare different versions of the translations of the content item.
 
 1\. [disable the Focus mode](../getting_started/discover_ui.md#disable-focus-mode).
 
-2\. In the left panel, go to **Content** -> **Content structure**. Then select a Content item.
+2\. In the left panel, go to **Content** -> **Content structure**. Then select a content item.
 
 3\. Go to **Versions** tab and click the **Version compare** icon: ![Version Compare Icon](img/version_compare_icon.png){.inline-image}.
 
@@ -56,7 +56,7 @@ You can compare different versions of the translations of the Content item.
 
 ![View switcher](img/view_switcher.png "View switcher")
 
-5\. From the drop-downs, select two different language versions of the same Content item.
+5\. From the drop-downs, select two different language versions of the same content item.
 The screen refreshes to display the side by side view of its Fields.
 
 ![Compare translations screen](img/compare_translations.png "Compare translations screen")

--- a/docs/content_management/work_with_forms.md
+++ b/docs/content_management/work_with_forms.md
@@ -24,7 +24,7 @@ To create a form:
 
 2\. In a slide-out pane, make initial choices in the following fields, and click **Create**:
 
-- **Select a language** - from a drop-down list, select the base language for the Content item.
+- **Select a language** - from a drop-down list, select the base language for the content item.
 - **Select a content type** - use this field to narrow down the list of content type choices displayed below. Then select **Form**, and click the **Create** button.
 
 ![Select form](img/select_form.png)
@@ -69,7 +69,7 @@ You can choose one of a few options of what is shown to the user after filling i
 
 ## View results
 
-Once you publish a form and users start filling it in, you can preview the results in the **Submissions** tab in the Content item view.
+Once you publish a form and users start filling it in, you can preview the results in the **Submissions** tab in the content item view.
 
 Here you can view the details of each submission.
 You can also delete any submissions (for example if they were made while testing or contain spam).
@@ -82,7 +82,7 @@ Click **Download submissions** icon to download all the submissions in a .CSV (c
 
 In the following example, you will learn how to create a Newsletter form and use it with Page Builder.
 
-1\. Create a new Content item in the chosen localization in the content tree and choose **Form** type.
+1\. Create a new content item in the chosen localization in the content tree and choose **Form** type.
 
 2\. Enter **Newsletter** as a title and click **Build** form.
 

--- a/docs/content_management/workflow_management/editorial_workflow.md
+++ b/docs/content_management/workflow_management/editorial_workflow.md
@@ -20,9 +20,9 @@ For example, you can pass content through stages of draft, design and proofreadi
 
 ## Review queue
 
-You can view Content items which are in different stages under review on the 
+You can view content items which are in different stages under review on the 
 **My dashboard** screen, in the Review queue table.
-The table only shows Content items that your Role has permissions to edit.
+The table only shows content items that your Role has permissions to edit.
 If your installation is [configured to support draft locking]([[= developer_doc =]]/content_management/workflow/workflow/#draft-locking), 
 the table also informs you whether any reviewers are assigned and have claimed 
 their drafts for review.

--- a/docs/content_management/workflow_management/view_workflow_list.md
+++ b/docs/content_management/workflow_management/view_workflow_list.md
@@ -12,7 +12,7 @@ You can preview a diagram of the workflow.
 
 ![Workflow diagram](img/workflow_diagram.png)
 
-You can also select a configured workflow to see all Content items that are under 
+You can also select a configured workflow to see all content items that are under 
 review as part of this workflow.
 
 ![Content under review](img/workflow_content_under_review.png)

--- a/docs/content_management/workflow_management/work_with_versions.md
+++ b/docs/content_management/workflow_management/work_with_versions.md
@@ -1,18 +1,18 @@
 ---
-description: Perform various tasks on Content item versions, as part of editorial workflow or when comparing edits from different users.
+description: Perform various tasks on content item versions, as part of editorial workflow or when comparing edits from different users.
 ---
 
 # Work with versions
 
-In [[= product_name =]], Content items can have one published [version](../content_versions.md), 
+In [[= product_name =]], content items can have one published [version](../content_versions.md), 
 and several draft and archived versions.
-You can perform various tasks on Content item versions, either to advance them 
+You can perform various tasks on content item versions, either to advance them 
 through the workflow or compare edits from different users.
 
 
 ## Edit drafts
 
-If you are assigned to a draft version of a Content item for [review](editorial_workflow.md), 
+If you are assigned to a draft version of a content item for [review](editorial_workflow.md), 
 when you click the **Edit draft** icon in **My dashboard**, the **Review queue** 
 table, you see the **Event(s)** timeline that lists all the transitions that this 
 content has gone through.
@@ -25,7 +25,7 @@ If draft locking is supported, you also see a message that confirms that the dra
 
 ## Release locked drafts
 
-If you are assigned to a draft version of a Content item and have locked it for 
+If you are assigned to a draft version of a content item and have locked it for 
 review, you can release the lock by closing the modal window, publishing the draft, 
 or sending it to another reviewer.
 You can also do it in **My dashboard**, the **Review queue** table, by clicking 
@@ -37,10 +37,10 @@ the **Unlock** icon, or request that the lock is released by the reviewer
 by clicking the **Request access** icon.
 
 ## Compare versions 
-You can compare two versions of the same Content item.
+You can compare two versions of the same content item.
 
 To do it, [disable the Focus mode](../../getting_started/discover_ui.md#disable-focus-mode).
-Then, in the Content item details screen, go to the **Versions** tab and click the 
+Then, in the content item details screen, go to the **Versions** tab and click the 
 **Version Compare** icon: ![Version Compare Icon](img/version_compare_icon.png){.inline-image}.
 
 From the drop-down menus at the top of the screen, select the two versions that you want to compare.

--- a/docs/customer_management/build_customer_portal.md
+++ b/docs/customer_management/build_customer_portal.md
@@ -21,7 +21,7 @@ Remember to specify its `location_id` in the configuration, you will find it und
 For more information, see [Configure Page Builder access to Customer Portal.]([[= developer_doc =]]/customer_management/cp_page_builder/#configure-page-builder-access-to-customer-portal)
 
 Inside a root folder you can select **Create content** from the right-side toolbar.
-On the list of Content items, you will see two possibilities **Customer Portal** and **Customer Portal Page**.
+On the list of content items, you will see two possibilities **Customer Portal** and **Customer Portal Page**.
 
 ![Create content tab](img/cp_portal_vs_page.png)
 

--- a/docs/getting_started/discover_ui.md
+++ b/docs/getting_started/discover_ui.md
@@ -19,7 +19,7 @@ Depending on your location within the Back Office, it can contain the following 
 !!! note "Site context"
 
     Changing the site context results in the [Content Tree](#content-tree) showing content items that belong to the selected website.
-    The appearance of Content items can also change if they use different designs or languages depending on the [SiteAccess](../website_organization/multisite.md#siteaccess) settings.
+    The appearance of content items can also change if they use different designs or languages depending on the [SiteAccess](../website_organization/multisite.md#siteaccess) settings.
 
 ![Top bar with site context selector](img/top_bar.png "Top bar with site context selector")
 
@@ -67,7 +67,7 @@ For more information on custom configuration, go to [Content Tree]([[= developer
 ## Content browser
 
 During your work with [[= product_name =]] you might need to select content from the Repository.
-This happens, for example, when you want to move or copy a Content item, embed an image, link two Content items, etc.
+This happens, for example, when you want to move or copy a content item, embed an image, link two content items, etc.
 In such cases, you use the **Content Browser**.
 
 To access the **Content Browser**, go to the **Content** tab and select **Content structure** or **Media**.
@@ -105,17 +105,17 @@ Settings unavailable in Content area
 ![Content tab in Focus mode](img/FM_menu_without_settings.png)
 
 Content item view
-: If you select a specific [SiteAccess](translate_content.md#siteaccess) from the **Site context** drop-down list on the right side of the top bar and then browse Content items in Content Tree, they are displayed in full view, with a limited set of actions available.
-To display the Content item details view with more actions, click **Exit full view**.
+: If you select a specific [SiteAccess](translate_content.md#siteaccess) from the **Site context** drop-down list on the right side of the top bar and then browse content items in Content Tree, they are displayed in full view, with a limited set of actions available.
+To display the content item details view with more actions, click **Exit full view**.
 
 ![Content item in full view](img/FM_content_item_full_view.png "Content item in full view")
 
 !!! tip
 
-    Even when you're out of the full view or not in Focus mode, you can still preview the Content item in the **View** tab.
+    Even when you're out of the full view or not in Focus mode, you can still preview the content item in the **View** tab.
 
 Different details view tabs in Focus mode and when it is disabled
-: In Focus mode, the tabs in Content item's detail view are different than the ones visible when it is disabled.
+: In Focus mode, the tabs in content item's detail view are different than the ones visible when it is disabled.
 Additionally, they are displayed in different order to expose the ones that are more important from the editor's perspective.
 
 ![Content item tabs in Focus mode](img/FM_less_ci_tabs.png "Content item tabs in Focus mode")

--- a/docs/image_management/edit_images.md
+++ b/docs/image_management/edit_images.md
@@ -5,7 +5,7 @@ description: Edit images in the Image Editor to flip, crop and select a focal po
 # Edit images
 
 When you browse the [Media library](content_model.md#content-and-media), 
-or create or edit a Content item that contains an *Image* 
+or create or edit a content item that contains an *Image* 
 or *Image asset* Field, you can perform basic image editing functions by using the Image Editor. 
 
 The Image Editor enables: 

--- a/docs/permission_management/permission_system.md
+++ b/docs/permission_management/permission_system.md
@@ -36,7 +36,7 @@ Local Editor, Sports Editor, etc. All of these Roles will have the same Policies
 but to each Policy you need to assign a Limitation which would mean that the permission covers only one Section
 (Sports Section, Local News Section etc.) that the editor works in.
 
-Aside from Policies that define access to Content items, there are also many other Policy types concerned with administrating the system.
+Aside from Policies that define access to content items, there are also many other Policy types concerned with administrating the system.
 They cover actions such as activating new Users, creating Sections, modifying content types, etc.
 
 

--- a/docs/permission_management/permissions_and_users.md
+++ b/docs/permission_management/permissions_and_users.md
@@ -4,7 +4,7 @@ description: Register users and use permission system to give them access to var
 
 # Manage permissions and users
 
-With the permission system of [[= product_name =]] you can control which users have access to which parts of the system, editorial features, and Content items that make the website.
+With the permission system of [[= product_name =]] you can control which users have access to which parts of the system, editorial features, and content items that make the website.
 
 [[= cards([
     "permission_management/permission_system",

--- a/docs/persona_paths/author_content.md
+++ b/docs/persona_paths/author_content.md
@@ -1,10 +1,10 @@
 ---
-description: Add and modify various Content items, such as pages, articles, forms, or media.
+description: Add and modify various content items, such as pages, articles, forms, or media.
 ---
 
 # Author content
 
-In [[= product_name =]] you store content data in Content items. Learn to add and modify various Content items, so that you can then show them to the audience.
+In [[= product_name =]] you store content data in content items. Learn to add and modify various content items, so that you can then show them to the audience.
 
 [[= cards([
     "content_management/content_items",

--- a/docs/persona_paths/organize_content.md
+++ b/docs/persona_paths/organize_content.md
@@ -1,10 +1,10 @@
 ---
-description: Organize the content of your website by copying or moving Content items, controlling Locations and URLs and classifying content.
+description: Organize the content of your website by copying or moving content items, controlling Locations and URLs and classifying content.
 ---
 
 # Organize content
 
-In [[= product_name =]] you store content data in Content items. Learn to add and modify various Content items, so that you can then show them to the audience.
+In [[= product_name =]] you store content data in content items. Learn to add and modify various content items, so that you can then show them to the audience.
 
 [[= cards([
     "content_management/content_organization/copy_move_hide_content",

--- a/docs/personalization/configure_models.md
+++ b/docs/personalization/configure_models.md
@@ -1,5 +1,5 @@
 ---
-description: Configure models by setting up a timeframe, segments and other settings that define which Content items are recommended.
+description: Configure models by setting up a timeframe, segments and other settings that define which content items are recommended.
 ---
 
 # Configure models

--- a/docs/personalization/configure_personalization.md
+++ b/docs/personalization/configure_personalization.md
@@ -1,5 +1,5 @@
 ---
-description: Configure your Personalization service by setting up models and scenarios which define which Content items are recommended.
+description: Configure your Personalization service by setting up models and scenarios which define which content items are recommended.
 ---
 
 # Configure personalization

--- a/docs/personalization/configure_scenarios.md
+++ b/docs/personalization/configure_scenarios.md
@@ -1,5 +1,5 @@
 ---
-description: Configure models by setting up a timeframe, segments and other settings that define which Content items are recommended.
+description: Configure models by setting up a timeframe, segments and other settings that define which content items are recommended.
 ---
 
 # Configure scenarios

--- a/docs/personalization/personalization.md
+++ b/docs/personalization/personalization.md
@@ -22,7 +22,7 @@ The most common ones are [eCommerce and content publishing](use_cases.md).
     Documentation mentions eCommerce use cases more often,
     but provides a thorough understanding of the content publishing context as well.
 
-    Both products and Content items can be referred to as content and the BUY [event](event_types.md) can be understood as
+    Both products and content items can be referred to as content and the BUY [event](event_types.md) can be understood as
     the CONSUME event.
 
 Before you can use the Personalization service, you must [enable it](enable_personalization.md).

--- a/docs/personalization/preview_scenario_results.md
+++ b/docs/personalization/preview_scenario_results.md
@@ -29,9 +29,9 @@ icon next to a scenario that you want to preview.
     No further configuration is required.
 
 1. If your scenario is based on models of [collaborative type](recommendation_models.md#collaborative-models), for example, 
-**Also clicked**, in the **Context items** area, in the **Set up items** field, and start typing Content item/product name or ID.
+**Also clicked**, in the **Context items** area, in the **Set up items** field, and start typing content item/product name or ID.
 
-    1. From the search results select the respective Content item/product.
+    1. From the search results select the respective content item/product.
     1. Click the **Add** button to confirm.
 
     ![Preview scenario](img/scenario_preview_content_search.png "Preview scenario")

--- a/docs/pim/create_edit_product.md
+++ b/docs/pim/create_edit_product.md
@@ -4,7 +4,7 @@ description: Create new products or modify existing ones.
 
 # Create and edit products
 
-[Products](products.md#products) are a specific kind of [Content items](../content_management/content_items.md#content-items) that you use 
+[Products](products.md#products) are a specific kind of [content items](../content_management/content_items.md#content-items) that you use 
 to present your offer in the website, including product specification, and pricing.
 Individual products are instances of [product types](create_product_types.md#create-product-types).
 You can only create or modify products when your [user Role](../permission_management/work_with_permissions.md) has the `Product/Edit` permission.

--- a/docs/search/search_for_content.md
+++ b/docs/search/search_for_content.md
@@ -8,9 +8,9 @@ You can enter a search keyword and the application checks all the searchable Fie
 ![Basic Search](img/basic_search.png)
 
 You can also select a language to search in.
-The results will contain Content items that are translated into this language.
+The results will contain content items that are translated into this language.
 
-The result list also shows which languages the Content item is translated to.
+The result list also shows which languages the content item is translated to.
 
 ## Filtered search
 

--- a/docs/search_engine_optimization/seo.md
+++ b/docs/search_engine_optimization/seo.md
@@ -27,8 +27,8 @@ A `Canonical` tag is used by the search engine's internal algorithm.
 After you define the tags for your content, they are rendered as part of the `<HEAD>` 
 section of a web page, from where the search engine intercepts their values.
 
-- `Title` is displayed as a prominent heading in the search. You want to make it relevant and attractive for users to click on. It represents the title of the Content item that you want to promote.
-- `Description` appears next to or below the title. Here you tell visitors what the content is about. Your goal is to optimize it for better visibility both on desktop and mobile.  It represents a summary of your Content item
+- `Title` is displayed as a prominent heading in the search. You want to make it relevant and attractive for users to click on. It represents the title of the content item that you want to promote.
+- `Description` appears next to or below the title. Here you tell visitors what the content is about. Your goal is to optimize it for better visibility both on desktop and mobile.  It represents a summary of your content item
 - `Keywords` can help the search engine position the results. Keywords can be ideas and topics that define what your content is about.
 - `Canonical URL` tells search engines which copy of content is the original that should appear in search results. It prevents duplicates from competing against each other.
 

--- a/docs/search_engine_optimization/work_with_seo.md
+++ b/docs/search_engine_optimization/work_with_seo.md
@@ -33,7 +33,7 @@ To learn more about the function of each of the tags, see [Meta tags](seo.md#met
 
 When you populate the SEO fields, you can create patterns by using a schema with 
 attributes which correspond to identifiers of fields that make up the content type.
-As a result, SEO tags are filled in at Content item generation phase with specific 
+As a result, SEO tags are filled in at content item generation phase with specific 
 contents of such fields. For example, if you enter `<title>.<format> - <author>` 
 as a value of the **Title** tag, the search engine will return 
 `Silmarillion. Illustrated edition - J.R.R. Tolkien`.
@@ -46,25 +46,25 @@ to configure the Facebook and Twitter presentation respectively.
 <!--If you leave these fields blank, social media snippets are generated based on 
 the definitions that you provided in the search engine meta tag fields.-->
 
-## Preview meta tags of Content item
+## Preview meta tags of content item
 
-You can preview what the actual SEO tags for a specific Content item 
+You can preview what the actual SEO tags for a specific content item 
 will look like when they are passed to a search engine or social media platform.
 
-1. In Content Tree, navigate to the Content item.
-2. On the Content item details screen, click the SEO tab.
+1. In Content Tree, navigate to the content item.
+2. On the content item details screen, click the SEO tab.
 3. Review the contents of the **resolved** fields.
 
-![SEO tab in Content item details](img/SEO_tab.png)`
+![SEO tab in content item details](img/SEO_tab.png)`
 
-## Override meta tags of Content item
+## Override meta tags of content item
 
-When you want a specific Content item to appear in search results differently than 
+When you want a specific content item to appear in search results differently than 
 the other items of a specific content type, you can override the contents of SEO tags.
 You might want, for example, to add a shout out to the title after the author of content 
 receives a literary prize.
 
-1. In Content Tree, navigate to the Content item, and click the **Edit** button.
+1. In Content Tree, navigate to the content item, and click the **Edit** button.
 2. Go to the **SEO** section and, in relevant fields, replace the patterns that 
 originate from the [content type definition](#define-meta-tags). 
 3. **Publish** your changes, **Save and close** or **Delete draft** to return to the Content Tree.

--- a/docs/user_management/manage_users.md
+++ b/docs/user_management/manage_users.md
@@ -4,12 +4,12 @@ description: You can view and manage user accounts in your system.
 
 # Manage users
 
-Users in [[= product_name =]] are treated the same way as other Content items.
+Users in [[= product_name =]] are treated the same way as other content items.
 They are organized in groups, which helps you manage them and their permissions.
 
 You can view all User Groups and Users in the **Admin Panel** by selecting **Users**.
 Here, you can manage users, their relations, Roles and Policies.
-As you can see, the interface is the same as when working with regular Content items.
+As you can see, the interface is the same as when working with regular content items.
 
 
 ![Users section](img/users_section.png)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,11 +19,11 @@ nav:
         - Configure content type Fields: content_management/configure_ct_field_settings.md
     - Content management:
         - Content items: content_management/content_items.md
-        - Create and edit Content items: content_management/create_edit_content_items.md
+        - Create and edit content items: content_management/create_edit_content_items.md
         - Create and edit pages: 
             - Create and edit pages: content_management/create_edit_pages.md
             - Block reference: content_management/block_reference.md
-        - Preview Content items: content_management/preview_content_items.md
+        - Preview content items: content_management/preview_content_items.md
         - Translate content: content_management/translate_content.md
         - Work with forms: content_management/work_with_forms.md
         - Taxonomy management:


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   |(https://issues.ibexa.co/browse/IBX-7909)
| Versions      | master

`Content item` changed to `content item` in User documentation.

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Added link to this PR in relevant JIRA ticket or code PR
