### PR TITLE
Fixed description of Sales Rep block

### DIFF
--- a/docs/content_management/block_reference.md
+++ b/docs/content_management/block_reference.md
@@ -292,7 +292,7 @@ On the **Properties** tab, set values in the following fields:
 
 - **Name** – Enter a name for the page block.
 
-On the **Design** tab, in the **View** field, select the layout to be used to present a list of products and submit your changes.
+On the **Design** tab, in the **View** field, select the layout to be used to present the Sales representative's details and submit your changes.
 
 ## SeenThis! block
 

--- a/docs/content_management/block_reference.md
+++ b/docs/content_management/block_reference.md
@@ -292,7 +292,7 @@ On the **Properties** tab, set values in the following fields:
 
 - **Name** – Enter a name for the page block.
 
-On the **Design** tab, in the **View** field, select the layout to be used to present the Sales representative's details and submit your changes.
+On the **Design** tab, in the **View** field, select the layout to be used to present the Sales representative's details view and submit your changes.
 
 ## SeenThis! block
 


### PR DESCRIPTION
The Sales Rep block displays Sales Rep's details and has nothing to do with products.

Target: master, 4.6

Preview: https://ez-systems-developer-documentation--302.com.readthedocs.build/projects/userguide/en/302/content_management/block_reference/#sales-representative