### PR TITLE
Add "external" icon to links to other domain

### DIFF
--- a/docs/js/custom.js
+++ b/docs/js/custom.js
@@ -75,6 +75,12 @@ $(document).ready(function() {
         }
     });
 
+    $('.md-content a:not(.md-icon):not(.md-source):not(.instantsearch__entry)')
+        .filter(function() {
+            return this.hostname && this.hostname !== location.hostname;
+        })
+        .addClass('external');
+
     docsearch({
         container: '#docsearch',
         appId: 'WLX2XJZTRM',


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | N/A
| Versions      | All
| Edition       | All

While the CSS is there, the JS to add the icon wasn't. Piece of code taken from https://github.com/ibexa/documentation-developer/blob/c636be472cab8f702d82f6ce3b0b2273beb6e916/docs/js/custom.js#L109-L113

Previews:
-  SeenThis! external link
    - https://doc.ibexa.co/projects/userguide/en/latest/content_management/block_reference/#seenthis-block without icon
    - https://ez-systems-developer-documentation--324.com.readthedocs.build/projects/userguide/en/324/content_management/block_reference/#seenthis-block with an icon
- Max tokens definition's "word" external link
    - https://doc.ibexa.co/projects/userguide/en/master/ai_actions/work_with_ai_actions/#edit-existing-ai-actions
    - https://ez-systems-developer-documentation--324.com.readthedocs.build/projects/userguide/en/324/ai_actions/work_with_ai_actions/#edit-existing-ai-actions with an icon (which pushes the quotation mark, maybe the quotation marks could be removed or moved inside the link).

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Added link to this PR in relevant JIRA ticket or code PR
