### PR TITLE
Fix links

### DIFF
--- a/docs/content_management/configure_ct_field_settings.md
+++ b/docs/content_management/configure_ct_field_settings.md
@@ -99,7 +99,7 @@ To do it, in the **Select Editor launch mode** section, select one of the availa
 
 When you add or modify a **[Content relation](create_edit_content_items.md#relation_field)** or **Content relation (multiple)** field in a content type, you can decide:
 
-- which content tree location opens in the [content browser](content_model.md#content-browser) when the user browses to a related content item
+- which content tree location opens in the [content browser](discover_ui.md#content-browser) when the user browses to a related content item
 - whether relations can be to content items of a specific type only, or any content type
 
 #### Relation starting location

--- a/docs/content_management/content_items.md
+++ b/docs/content_management/content_items.md
@@ -11,7 +11,7 @@ These fields can differ depending on what kind of content you're dealing with.
 An *article* content item may consist of fields, for example, *title*, *name*, *author*, *body*, *image*, or *subscriber teaser*.
 A *product* content item may have, for example, *product name*, *category*, *price*, *size*, or *color*, as fields.
 
-In [[= product_name =]], you create content items based on templated called [content types](content_model.md#content_types).
+In [[= product_name =]], you create content items based on templated called [content types](content_model.md#content-types).
 
 ## Access content in the UI
 

--- a/docs/content_management/content_organization/classify_content.md
+++ b/docs/content_management/content_organization/classify_content.md
@@ -53,7 +53,7 @@ Click **Bookmarks** in the left menu to view a list of all of them.
 
 With segments you can target content at specific groups of your users.
 You can use them to display different content to different page visitors.
-To do it, use the [Targeting block](create_edit_pages.md#targeting-block).
+To do it, use the [Targeting block](block_reference.md#targeting-block).
 
 You can create and configure segments and segment groups in the **Admin** section of the back office.
 

--- a/docs/content_management/content_organization/copy_move_hide_content.md
+++ b/docs/content_management/content_organization/copy_move_hide_content.md
@@ -82,13 +82,13 @@ This is different from [hiding locations](manage_locations_urls.md#hide-location
 
 !!! caution "Visibility and permissions"
 
-    The [visibility switcher](https://doc.ibexa.co/projects/userguide/en/latest/content_management/content_organization/manage_locations_urls/#hide-locations) is a convenient feature for withdrawing content from the frontend.
+    The [visibility switcher](manage_locations_urls.md#hide-locations) is a convenient feature for withdrawing content from the frontend.
     It acts as a filter in the frontend by default. You can choose to respect it or ignore it in your code.
     It's not permission-based, and **doesn't restrict access to content**.
     Hidden content can be read through other means, like the REST API.
 
     If you need to restrict access to a given content item, you could create a role that grants read access for a given
-    [**Section**](https://doc.ibexa.co/projects/userguide/en/latest/content_management/content_organization/classify_content/#sections)
-    or [**Object State**](https://doc.ibexa.co/projects/userguide/en/latest/content_management/content_organization/classify_content/#object-states),
+    [**Section**](classify_content.md#sections)
+    or [**Object State**](classify_content.md#object-states),
     and set a different section or object state for the given content.
-    Or use other permission-based [**Limitations**](https://doc.ibexa.co/projects/userguide/en/latest/permission_management/work_with_permissions/).
+    Or use other permission-based [**Limitations**](work_with_permissions.md).

--- a/docs/content_management/create_edit_pages.md
+++ b/docs/content_management/create_edit_pages.md
@@ -270,4 +270,4 @@ There are several options for saving work on the page:
 |Save draft|Save the page draft*.|
 |Delete draft|Delete the page draft.|
 
-* To help you preserve your work, system saves drafts of content items automatically. For more information, see [Autosave](https://doc.ibexa.co/projects/userguide/en/master/content_management/content_versions/#autosave).
+* To help you preserve your work, system saves drafts of content items automatically. For more information, see [Autosave](content_versions.md#autosave).

--- a/docs/content_management/create_edit_pages.md
+++ b/docs/content_management/create_edit_pages.md
@@ -23,7 +23,7 @@ Whenever you edit a page, a [new version](content_versions.md) is created in the
 1. In a slide-out pane, make initial choices in the following fields, and click **Create**:
     - **Select a language** - from a drop-down list, select the base language for the content item.
     - **Select a content type** - use this field to narrow down the list of content type choices displayed below. Then select one of page type, for example, **Landing page**, and click the **Create** button.
-1. In the [Page Builder toolbar](#page-builder-toolbar) click **Fields** and define the page's title and description.
+1. In the [Page Builder toolbar](#page-builder-interface) click **Fields** and define the page's title and description.
 1. Click  **Switch layout** and select the layout.
 1. [Edit the page](#edit-page).
 1. To discard your changes and close the window, click **Delete draft**.

--- a/docs/content_management/translate_content.md
+++ b/docs/content_management/translate_content.md
@@ -65,7 +65,7 @@ For more information, see [Work with versions](work_with_versions.md#compare-ver
 
 ## Edit page for different language versions of a website [[% include 'snippets/experience_badge.md' %]] [[% include 'snippets/commerce_badge.md' %]]
 
-When you edit a page, a bar at the top of the screen lists the most recently used [SiteAccesses](https://doc.ibexa.co/projects/userguide/en/master/website_organization/multisite/#siteaccess) on your website.
+When you edit a page, a bar at the top of the screen lists the most recently used [SiteAccesses](multisite.md#siteaccess) on your website.
 Use this bar to switch between the different versions and work on them.
 
 <a name="siteaccess"></a>

--- a/docs/getting_started/get_started.md
+++ b/docs/getting_started/get_started.md
@@ -106,7 +106,7 @@ Here you can [change your user password](get_started.md#change-the-password) and
 
 |Setting|Description|
 --------|-----------|
-|[Autosave draft every given period](../content_management/content_versions.md/#autosave)|Enables or disables autosaving drafts.|
+|[Autosave draft every given period](content_versions.md#autosave)|Enables or disables autosaving drafts.|
 |Seconds till next draft autosave|Sets time period for next autosave.|
 |Enable character count in online editor|Enables or disables charactes count.|
 |Automatically open block settings in builders|Enables or disables the behavior of blocks used in builders.|

--- a/docs/image_management/upload_images.md
+++ b/docs/image_management/upload_images.md
@@ -77,4 +77,4 @@ To upload multiple images and create many image assets, you can use multi-file u
 If you work with multiple languages and want to use searching by languages in DAM, you can add translations to image assets.
 You can replace the contents of all the fields that have values in the base language, for example, the description, or the alternative text.
 
-To see how to add translations, go to [translate content section](../content_management/translate_content.md/#add-translations).
+To see how to add translations, go to [translate content section](translate_content.md#add-translations).

--- a/docs/personalization/configure_scenarios.md
+++ b/docs/personalization/configure_scenarios.md
@@ -48,7 +48,7 @@ Add several models to every strategy level to avoid empty or insufficient recomm
 From the **Data type** and **Context** drop-downs, select the required options to group items based on supported data types for the model.
 You can choose between **Submodels** or **Segments** data types.
 
-If selected models support additional differentiators, you can apply them here. For more information about available model settings, see [Advanced model configuration](recommendation_models.md#advanced-model-configuration).
+If selected models support additional differentiators, you can apply them here. For more information about available model settings, see [Advanced model configuration](configure_models.md#advanced-model-configuration).
 
 !!! note
 

--- a/docs/personalization/filters.md
+++ b/docs/personalization/filters.md
@@ -58,7 +58,7 @@ The following filters are only applicable in Commerce use cases.
 |Minimum price of the recommended product|You can use this filter to remove cheap and popular items from the recommendation list. For example, as an optometrist you might prefer showing the most popular designer frames on the home page and avoid promoting insurance subsidized cheap models or cleaning cloths. Again, this filter relies on product metadata and uses prices exported to the Personalization service.|
 |Do not recommend if price unknown|If a product's price is unavailable then the product isn't recommended.|
 |Do not recommend items the user already purchased|When you activate this filter, the user isn't recommended to purchase products again.|
-|Do not recommend product variants| By default, this filter is deactivated: only [product variants](../pim/products.md#product-variants) are recommended and base products aren't recommended. When you activate this filter, a recommendation response includes base products, while product variants are excluded. The filter doesn't affect products that have no variants. |
+|Do not recommend product variants| By default, this filter is deactivated: only [product variants](work_with_product_variants.md) are recommended and base products aren't recommended. When you activate this filter, a recommendation response includes base products, while product variants are excluded. The filter doesn't affect products that have no variants. |
 
 !!! note "Product variants support"
 

--- a/docs/personalization/personalization.md
+++ b/docs/personalization/personalization.md
@@ -25,4 +25,4 @@ Finally, you can [feed it with data](content_import.md), or wait until the servi
 On a website with more than 100 clicks per day, a day of collecting data should be sufficient for the first recommendations to be relevant.
 Recommendations become better with time and the amount of data collected.
 
-For more information about Personalization, see [Ibexa blog](https://www.ibexa.co/blog/ibexa-dxp-v3.3-new-feature-preview-personalization-simplified-and-dxp-integrated) or a [downloadable eBook](https://www.ibexa.co/events/ibexa-engage-2021/resources/downloads/the-basics-of-personalization).
+For more information about Personalization, see [Ibexa blog](https://www.ibexa.co/blog/ibexa-dxp-v3.3-new-feature-preview-personalization-simplified-and-dxp-integrated) or a [downloadable eBook](https://www.ibexa.co/resources/ebooks-analyst-reports/the-basics-of-personalization).

--- a/docs/personalization/recommendation_models.md
+++ b/docs/personalization/recommendation_models.md
@@ -121,7 +121,7 @@ It means, for example, that if the pattern covers 100 days, when the optimal tim
 ### B2B model
 
 This model shows which items were recently clicked or bought for a particular segment group of a company.
-B2B models work for a group of users, not for an individual user, and are considered [segment](configure_models.md#configure-segments) models.
+B2B models work for a group of users, not for an individual user, and are considered [segment](segment_management.md) models.
 
 !!! note
 

--- a/docs/personalization/triggers.md
+++ b/docs/personalization/triggers.md
@@ -42,7 +42,7 @@ You can define one or more triggers of certain type, to support different use ca
 For each trigger type, you need to decide on several crucial parameters, for example:
 
 - one or more [types of content](content_types.md)
-- [attributes](recommendation_models.md/#nominal-attributes) to be included in the response
+- [attributes](recommendation_models.md#nominal-attributes) to be included in the response
 - time that must pass before messages start being sent
 - number of repetitions
 - message frequency
@@ -52,4 +52,3 @@ For each trigger type, you need to decide on several crucial parameters, for exa
 "Also purchased", "Also clicked", and "Top purchased" are used by default.
 
 If you don't decide otherwise, trigger recipients are selected based on an analysis of BUY and TRANSFER events, except for the "Price drop" trigger, where the WISHLIST event is analyzed.
-

--- a/docs/pim/create_virtual_product.md
+++ b/docs/pim/create_virtual_product.md
@@ -9,7 +9,7 @@ Virtual product is a special type of a [Product](products.md).
 Virtual products are non-tangible items such as memberships, services, warranties.
 They can be sold individually, or as part of a product bundle.
 
-Like physical products, virtual products can have their own [variants](work_with_product_variants.md), [assets](work_with_product_assets.md) or [attributes](products.md#attributes).
+Like physical products, virtual products can have their own [variants](work_with_product_variants.md), [assets](work_with_product_assets.md) or [attributes](work_with_product_attributes.md).
 You can also create catalogs from them, check their completeness and set [prices, availability, and stock](manage_availability_and_stock.md).
 
 ## Create virtual product type
@@ -46,6 +46,3 @@ Virtual products don’t require shipment when they're purchased without other p
 While purchasing a virtual product, you only have to fill in Billing address and select relevant payment method.
 
 ![Virtual product purchasing](virtual_product_purchase.png "Virtual product purchasing")
-
-
-

--- a/docs/pim/work_with_product_attributes.md
+++ b/docs/pim/work_with_product_attributes.md
@@ -4,7 +4,7 @@ description: Create a structure of attributes that describe product characterist
 
 # Work with product attributes
 
-[Attributes](products.md#attributes) describe physical, technical or other characteristics of a product.
+Attributes describe physical, technical or other characteristics of a product.
 They're organized into attribute groups, and when you assign attributes to products, you can assign either whole groups, or individual attributes.
 You can use attributes to create multiple versions of one product, called [product variants](work_with_product_variants.md).
 Store visitors can use them to filter and search for products.

--- a/docs/pim/work_with_product_page_urls.md
+++ b/docs/pim/work_with_product_page_urls.md
@@ -21,7 +21,7 @@ Now, you can see new URL alias name pattern in the product type's view.
 
 ## Product Attributes identifiers
 
-Products have their own [attributes](products.md#attributes) to define product specification.
+Products have their own [attributes](work_with_product_attributes.md) to define product specification.
 
 The following attribute types can be used in URL alias name pattern field:
 
@@ -74,6 +74,3 @@ Now, in the **URL** tab in the product's view, you can see new custom URL for th
 ![Custom URL](custom_url.png "Custom URL")
 
 You can manage all the product URLs, both system and custom ones: create new and edit or delete existing ones.
-
-
-

--- a/docs/search_engine_optimization/seo.md
+++ b/docs/search_engine_optimization/seo.md
@@ -34,4 +34,4 @@ It prevents duplicates from competing against each other.
 Additionally, you can define social media-specific meta tags separately, to fine-tune the message that gets across to each of the platforms.
 If you fail to use this feature, the default meta tags are used to generate a social media snippet.
 
-For more information about SEO, see [Ibexa blog](https://www.ibexa.co/blog/five-useful-seo-techniques-for-ez-platform-developers).
+For more information about SEO, see [Ibexa blog](https://www.ibexa.co/blog-archive/five-useful-seo-techniques-for-ez-platform-developers).

--- a/docs/search_engine_optimization/work_with_seo.md
+++ b/docs/search_engine_optimization/work_with_seo.md
@@ -6,7 +6,7 @@ description: Enable search engine optimization and increase content visibility b
 
 For the Search Engine Optimization (SEO) feature to help you optimize the searchability and visibility of your content, you must enable it first, and then, define the contents of individual tags.
 
-To do it, make sure you can [edit content types](../content_management/content_model.md#content_types).
+To do it, make sure you can [edit content types](content_model.md#content-types).
 
 ## Enable SEO
 

--- a/docs/search_engine_optimization/work_with_seo.md
+++ b/docs/search_engine_optimization/work_with_seo.md
@@ -6,7 +6,7 @@ description: Enable search engine optimization and increase content visibility b
 
 For the Search Engine Optimization (SEO) feature to help you optimize the searchability and visibility of your content, you must enable it first, and then, define the contents of individual tags.
 
-To do it, make sure you can [edit content types](content_model.md#content-types).
+To do it, make sure you can [edit content types](create_edit_content_types.md).
 
 ## Enable SEO
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | N/A
| Versions      | master, 4.6
| Edition       | All

Fix several broken links.

Including [`products.md#attributes` which ceases to exists in #248](https://github.com/ibexa/documentation-user/pull/248/files#diff-2f38cc72c81070285fb64bd7299a343dff30d22a6baccef08ea08ba87e66a878L39), probably in favor of [work_with_product_attributes.md](https://ez-systems-developer-documentation--338.com.readthedocs.build/projects/userguide/en/338/pim/work_with_product_attributes/).

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Added link to this PR in relevant JIRA ticket or code PR
