### PR TITLE
Fix version switcher order

### DIFF
--- a/docs/js/custom.js
+++ b/docs/js/custom.js
@@ -58,7 +58,7 @@ $(document).ready(function() {
             $('.rst-current-version.switcher__label').html(version.length ? version : 'Change version');
             $('.rst-other-versions.switcher__list dl.versions dd strong').parent().addClass('rtd-current-item');
 
-            if ('master' !== (vl = $('.rst-other-versions.switcher__list dl.versions')).find('dd:first').text()) {
+            if ('latest' !== (vl = $('.rst-other-versions.switcher__list dl.versions')).find('dd:first').text()) {
                 vl.find('dd').each(function() {
                     $(this).detach().prependTo(vl);
                 });


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | N/A
| Versions      | All
| Edition       | All

Sort version switcher from newest to oldest versions.

Version switcher was seemingly already from newer to older before master was hidden.

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Added link to this PR in relevant JIRA ticket or code PR
